### PR TITLE
Support CALLED_BY searches from XrefNode, and support CodeBlock lookups from CsFile.

### DIFF
--- a/codesearch/test_client_api.py
+++ b/codesearch/test_client_api.py
@@ -16,7 +16,8 @@ import unittest
 
 from .client_api import CodeSearch, XrefNode
 from .messages import CompoundRequest, CompoundResponse, FileInfoRequest, \
-        FileInfoResponse, KytheNodeKind, KytheXrefKind, NodeEnumKind
+        FileInfoResponse, KytheNodeKind, KytheXrefKind, NodeEnumKind, \
+        CallGraphRequest, CallGraphResponse, Node
 from .testing_support import InstallTestRequestHandler, LastRequest, \
         TestDataDir, DisableNetwork, EnableNetwork, DumpCallers
 
@@ -112,6 +113,17 @@ class TestCodeSearch(unittest.TestCase):
         NodeEnumKind.METHOD,
         return_all_results=True)
     self.assertEqual(2, len(signatures))
+
+  def test_get_call_graph(self):
+    cs = CodeSearch(source_root='.')
+    signatures = cs.SearchForSymbol('HttpAuth::ChooseBestChallenge',
+                                    NodeEnumKind.FUNCTION)
+    self.assertEqual(1, len(signatures))
+    self.assertIsInstance(signatures[0], XrefNode)
+    cg_response = cs.GetCallGraph(signature=signatures[0].GetSignature())
+    self.assertIsInstance(cg_response, CompoundResponse)
+    self.assertIsInstance(cg_response.call_graph_response[0], CallGraphResponse)
+    self.assertIsInstance(cg_response.call_graph_response[0].node, Node)
 
   def test_fixed_cache(self):
     fixed_cache_dir = os.path.join(TestDataDir(), 'fixed_cache')

--- a/codesearch/test_codeblocks.py
+++ b/codesearch/test_codeblocks.py
@@ -1,0 +1,46 @@
+# Copyright 2018 The Chromium Authors.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd.
+
+import unittest
+
+from .client_api import CsFile, CodeSearch
+from .messages import FileInfo, TextRange, NodeEnumKind, CodeBlock, CodeBlockType
+from .testing_support import InstallTestRequestHandler
+
+
+class TestCodeBlocks(unittest.TestCase):
+
+  def setUp(self):
+    InstallTestRequestHandler()
+
+  def test_get_codeblock(self):
+    cs = CodeSearch(source_root='/src/chrome/')
+    cs_file = cs.GetFileInfo('/src/chrome/src/net/http/http_auth.h')
+    block = cs_file.GetCodeBlock()
+    self.assertIsInstance(block, CodeBlock)
+    self.assertNotEqual(0, len(block.child))
+    self.assertIsInstance(block.child[0], CodeBlock)
+
+  def test_find(self):
+    cs = CodeSearch(source_root='/src/chrome/')
+    cs_file = cs.GetFileInfo('/src/chrome/src/net/http/http_auth.h')
+    block = cs_file.FindCodeBlock()
+    self.assertIsNotNone(block)
+    self.assertIsInstance(block, CodeBlock)
+    self.assertEqual(block, cs_file.GetCodeBlock(), "should match root")
+
+    block = cs_file.FindCodeBlock("net", CodeBlockType.NAMESPACE)
+    self.assertIsNotNone(block)
+    self.assertEqual(block.name, "net")
+
+    block = cs_file.FindCodeBlock("HandleChallengeResponse",
+                                  CodeBlockType.FUNCTION)
+    self.assertIsNotNone(block)
+    self.assertEqual(block.name, "HandleChallengeResponse")
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/codesearch/test_cs_file.py
+++ b/codesearch/test_cs_file.py
@@ -7,7 +7,7 @@
 import unittest
 
 from .client_api import CsFile, CodeSearch
-from .messages import FileInfo, TextRange, NodeEnumKind
+from .messages import FileInfo, TextRange, NodeEnumKind, CodeBlock, CodeBlockType
 from .testing_support import InstallTestRequestHandler
 
 
@@ -51,6 +51,24 @@ class TestCsFile(unittest.TestCase):
         cs_file.GetAnchorText(
             'kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#HttpAuth%3Anet%23c%23hUTvau_Z32C'
         ), 'HttpAuth')
+
+  def test_get_codeblock(self):
+    cs = CodeSearch(source_root='/src/chrome/')
+    cs_file = cs.GetFileInfo('/src/chrome/src/net/http/http_auth.h')
+    block = cs_file.GetCodeBlock()
+    self.assertIsInstance(block, CodeBlock)
+    self.assertNotEqual(0, len(block.child))
+    self.assertIsInstance(block.child[0], CodeBlock)
+
+  def test_get_signature_for_codeblock(self):
+    cs = CodeSearch(source_root='/src/chrome/')
+    cs_file = cs.GetFileInfo('/src/chrome/src/net/http/http_auth.h')
+    block = cs_file.FindCodeBlock(
+        name="AuthorizationResult", type=CodeBlockType.ENUM)
+    self.assertIsNotNone(block)
+    sig = cs_file.GetSignatureForCodeBlock(block)
+    self.assertIsNotNone(sig)
+    self.assertNotEqual("", sig)
 
 
 if __name__ == '__main__':

--- a/codesearch/test_messages.py
+++ b/codesearch/test_messages.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 
 import unittest
 
-from .messages import Message, message, XrefSignature, InternalLink
+from .messages import Message, message, XrefSignature, InternalLink, TextRange
 
 
 @message
@@ -160,6 +160,71 @@ class TestInternalLink(unittest.TestCase):
         set(['foo', 'bar', 'baz', 'hifoo', 'hibar']),
         set(ilink.GetSignatures()))
     self.assertEqual('foo', ilink.GetSignature())
+
+
+class TestTextRange(unittest.TestCase):
+
+  def test_contains(self):
+    r = TextRange(start_line=1, start_column=8, end_line=3, end_column=1)
+    self.assertTrue(r.Contains(1, 8))
+    self.assertTrue(r.Contains(3, 1))
+    self.assertTrue(r.Contains(2, 100))
+    self.assertFalse(r.Contains(1, 7))
+    self.assertFalse(r.Contains(3, 2))
+
+  def test_overlaps(self):
+
+    def _QuadToRange(q):
+      return TextRange(
+          start_line=q[0], start_column=q[1], end_line=q[2], end_column=q[3])
+
+    TestCases = [
+        {
+            "r1": (2, 8, 2, 9),
+            "r2": (1, 1, 1, 100),
+            "result": False
+        },
+        {
+            "r1": (2, 8, 2, 9),
+            "r2": (2, 6, 2, 7),
+            "result": False
+        },
+        {
+            "r1": (2, 8, 2, 9),
+            "r2": (2, 6, 2, 8),
+            "result": True
+        },
+        {
+            "r1": (2, 8, 3, 9),
+            "r2": (2, 6, 2, 8),
+            "result": True
+        },
+        {
+            "r1": (2, 8, 4, 9),
+            "r2": (3, 6, 3, 800),
+            "result": True
+        },
+        {
+            "r1": (2, 8, 4, 9),
+            "r2": (1, 6, 3, 800),
+            "result": True
+        },
+        {
+            "r1": (2, 8, 4, 9),
+            "r2": (3, 6, 300, 800),
+            "result": True
+        },
+        {
+            "r1": (2, 8, 4, 9),
+            "r2": (1, 6, 2, 7),
+            "result": False
+        },
+    ]
+    for t in TestCases:
+      r1 = _QuadToRange(t["r1"])
+      r2 = _QuadToRange(t["r2"])
+      self.assertEqual(t["result"], r1.Overlaps(r2))
+      self.assertEqual(t["result"], r2.Overlaps(r1))
 
 
 if __name__ == '__main__':

--- a/codesearch/testdata/responses/1c08d227414f968add2f655bae338d907b3089c9.json
+++ b/codesearch/testdata/responses/1c08d227414f968add2f655bae338d907b3089c9.json
@@ -1,0 +1,80 @@
+{
+  "elapsed_ms": 8, 
+  "call_graph_response": [
+    {
+      "node": {
+        "node_kind": "FUNCTION", 
+        "children": [
+          {
+            "call_scope_range": {
+              "start_line": 222, 
+              "end_line": 222, 
+              "start_column": 25, 
+              "end_column": 43
+            }, 
+            "package_name": "chromium", 
+            "snippet_package_name": "chromium", 
+            "call_site_range": {
+              "start_line": 288, 
+              "end_line": 290, 
+              "start_column": 7, 
+              "end_column": 74
+            }, 
+            "snippet": {
+              "text": {
+                "text": "      HttpAuth::ChooseBestChallenge(http_auth_handler_factory_, *headers,"
+              }, 
+              "first_line_number": 288
+            }, 
+            "snippet_file_path": "src/net/http/http_auth_controller.cc", 
+            "node_kind": "FUNCTION", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_controller.cc#GtcwscFl%2FOrKkHN649fanpArN6xKK%2BDVhhEx%2BfB2FAw%3D", 
+            "params": [
+              "headers", 
+              "ssl_info", 
+              "do_not_send_server_auth", 
+              "establishing_tunnel", 
+              "net_log"
+            ], 
+            "identifier": "HandleAuthChallenge", 
+            "file_path": "src/net/http/http_auth_controller.cc"
+          }, 
+          {
+            "call_scope_range": {
+              "start_line": 69, 
+              "end_line": 69, 
+              "start_column": 1, 
+              "end_column": 0
+            }, 
+            "package_name": "chromium", 
+            "snippet_package_name": "chromium", 
+            "call_site_range": {
+              "start_line": 143, 
+              "end_line": 146, 
+              "start_column": 5, 
+              "end_column": 43
+            }, 
+            "snippet": {
+              "text": {
+                "text": "    HttpAuth::ChooseBestChallenge(http_auth_handler_factory.get(), *headers,"
+              }, 
+              "first_line_number": 143
+            }, 
+            "snippet_file_path": "src/net/http/http_auth_unittest.cc", 
+            "node_kind": "FUNCTION", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_unittest.cc#vtn7oC2qNLbsyur%2FnHW4k29lNdRnYtP%2Ftori3r9RwRo%3D", 
+            "identifier": "TestBody", 
+            "file_path": "src/net/http/http_auth_unittest.cc"
+          }
+        ], 
+        "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#Nrxbg2wUMb7TnDHlFpxZyOQVIkRE3PT9Fb4TKk23Pqg%3D"
+      }, 
+      "is_from_kythe": true, 
+      "return_code": 1, 
+      "results_offset": 0, 
+      "estimated_total_number_results": 2, 
+      "is_call_graph": true, 
+      "kythe_next_page_token": ""
+    }
+  ]
+}

--- a/codesearch/testdata/responses/786ca57850bdf6a58f939013e3d99f4d58079694.json
+++ b/codesearch/testdata/responses/786ca57850bdf6a58f939013e3d99f4d58079694.json
@@ -1,0 +1,127 @@
+{
+  "elapsed_ms": 20, 
+  "file_info_response": [
+    {
+      "file_info": {
+        "gob_info": {
+          "repo": "chromium/chromium/src", 
+          "commit": "eca9e3231355e561117f767c424c65ed9f484bcd", 
+          "path": "net/http/http_auth.cc"
+        }, 
+        "name": "src/net/http/http_auth.cc", 
+        "language": "c++", 
+        "changelist_num": "eca9e3231355e561117f767c424c65ed9f484bcd", 
+        "package_name": "chromium", 
+        "lines": "145", 
+        "content": {
+          "text": "// Copyright (c) 2011 The Chromium Authors. All rights reserved.\n// Use of this source code is governed by a BSD-style license that can be\n// found in the LICENSE file.\n\n#include \"net/http/http_auth.h\"\n\n#include <algorithm>\n\n#include \"base/strings/string_tokenizer.h\"\n#include \"base/strings/string_util.h\"\n#include \"net/base/net_errors.h\"\n#include \"net/http/http_auth_challenge_tokenizer.h\"\n#include \"net/http/http_auth_handler.h\"\n#include \"net/http/http_auth_handler_factory.h\"\n#include \"net/http/http_auth_scheme.h\"\n#include \"net/http/http_request_headers.h\"\n#include \"net/http/http_response_headers.h\"\n#include \"net/http/http_util.h\"\n\nnamespace net {\n\nHttpAuth::Identity::Identity() : source(IDENT_SRC_NONE), invalid(true) {}\n\n// static\nvoid HttpAuth::ChooseBestChallenge(\n    HttpAuthHandlerFactory* http_auth_handler_factory,\n    const HttpResponseHeaders& response_headers,\n    const SSLInfo& ssl_info,\n    Target target,\n    const GURL& origin,\n    const std::set<Scheme>& disabled_schemes,\n    const NetLogWithSource& net_log,\n    std::unique_ptr<HttpAuthHandler>* handler) {\n  DCHECK(http_auth_handler_factory);\n  DCHECK(handler->get() == NULL);\n\n  // Choose the challenge whose authentication handler gives the maximum score.\n  std::unique_ptr<HttpAuthHandler> best;\n  const std::string header_name = GetChallengeHeaderName(target);\n  std::string cur_challenge;\n  size_t iter = 0;\n  while (response_headers.EnumerateHeader(&iter, header_name, &cur_challenge)) {\n    std::unique_ptr<HttpAuthHandler> cur;\n    int rv = http_auth_handler_factory->CreateAuthHandlerFromString(\n        cur_challenge, target, ssl_info, origin, net_log, &cur);\n    if (rv != OK) {\n      VLOG(1) << \"Unable to create AuthHandler. Status: \"\n              << ErrorToString(rv) << \" Challenge: \" << cur_challenge;\n      continue;\n    }\n    if (cur.get() && (!best.get() || best->score() < cur->score()) &&\n        (disabled_schemes.find(cur->auth_scheme()) == disabled_schemes.end()))\n      best.swap(cur);\n  }\n  handler->swap(best);\n}\n\n// static\nHttpAuth::AuthorizationResult HttpAuth::HandleChallengeResponse(\n    HttpAuthHandler* handler,\n    const HttpResponseHeaders& response_headers,\n    Target target,\n    const std::set<Scheme>& disabled_schemes,\n    std::string* challenge_used) {\n  DCHECK(handler);\n  DCHECK(challenge_used);\n  challenge_used->clear();\n  HttpAuth::Scheme current_scheme = handler->auth_scheme();\n  if (disabled_schemes.find(current_scheme) != disabled_schemes.end())\n    return HttpAuth::AUTHORIZATION_RESULT_REJECT;\n  std::string current_scheme_name = SchemeToString(current_scheme);\n  const std::string header_name = GetChallengeHeaderName(target);\n  size_t iter = 0;\n  std::string challenge;\n  HttpAuth::AuthorizationResult authorization_result =\n      HttpAuth::AUTHORIZATION_RESULT_INVALID;\n  while (response_headers.EnumerateHeader(&iter, header_name, &challenge)) {\n    HttpAuthChallengeTokenizer props(challenge.begin(), challenge.end());\n    if (!base::LowerCaseEqualsASCII(props.scheme(),\n                                    current_scheme_name.c_str()))\n      continue;\n    authorization_result = handler->HandleAnotherChallenge(&props);\n    if (authorization_result != HttpAuth::AUTHORIZATION_RESULT_INVALID) {\n      *challenge_used = challenge;\n      return authorization_result;\n    }\n  }\n  // Finding no matches is equivalent to rejection.\n  return HttpAuth::AUTHORIZATION_RESULT_REJECT;\n}\n\n// static\nstd::string HttpAuth::GetChallengeHeaderName(Target target) {\n  switch (target) {\n    case AUTH_PROXY:\n      return \"Proxy-Authenticate\";\n    case AUTH_SERVER:\n      return \"WWW-Authenticate\";\n    default:\n      NOTREACHED();\n      return std::string();\n  }\n}\n\n// static\nstd::string HttpAuth::GetAuthorizationHeaderName(Target target) {\n  switch (target) {\n    case AUTH_PROXY:\n      return HttpRequestHeaders::kProxyAuthorization;\n    case AUTH_SERVER:\n      return HttpRequestHeaders::kAuthorization;\n    default:\n      NOTREACHED();\n      return std::string();\n  }\n}\n\n// static\nstd::string HttpAuth::GetAuthTargetString(Target target) {\n  switch (target) {\n    case AUTH_PROXY:\n      return \"proxy\";\n    case AUTH_SERVER:\n      return \"server\";\n    default:\n      NOTREACHED();\n      return std::string();\n  }\n}\n\n// static\nconst char* HttpAuth::SchemeToString(Scheme scheme) {\n  static const char* const kSchemeNames[] = {\n      kBasicAuthScheme,     kDigestAuthScheme,    kNtlmAuthScheme,\n      kNegotiateAuthScheme, kSpdyProxyAuthScheme, kMockAuthScheme};\n  static_assert(arraysize(kSchemeNames) == AUTH_SCHEME_MAX,\n                \"http auth scheme names incorrect size\");\n  if (scheme < AUTH_SCHEME_BASIC || scheme >= AUTH_SCHEME_MAX) {\n    NOTREACHED();\n    return \"invalid_scheme\";\n  }\n  return kSchemeNames[scheme];\n}\n\n}  // namespace net\n"
+        }, 
+        "generated": false, 
+        "mime_type": "text/plain", 
+        "size": "4775", 
+        "type": 1, 
+        "md5": "1ef714d7c42e0381233a338869376e7a", 
+        "codeblock": [
+          {
+            "child": [
+              {
+                "name_prefix": "HttpAuth::Identity::", 
+                "type": 8, 
+                "name": "Identity", 
+                "text_range": {
+                  "start_line": 22, 
+                  "end_line": 22, 
+                  "start_column": 1, 
+                  "end_column": 74
+                }, 
+                "signature": "()"
+              }, 
+              {
+                "name_prefix": "HttpAuth::", 
+                "type": 8, 
+                "name": "ChooseBestChallenge", 
+                "text_range": {
+                  "start_line": 25, 
+                  "end_line": 56, 
+                  "start_column": 1, 
+                  "end_column": 2
+                }, 
+                "signature": "(HttpAuthHandlerFactory* http_auth_handler_factory, const HttpResponseHeaders& response_headers, const SSLInfo& ssl_info, Target target, const GURL& origin, const std::set<Scheme>& disabled_schemes, const NetLogWithSource& net_log, std::unique_ptr<HttpAuthHandler>* handler)"
+              }, 
+              {
+                "name_prefix": "HttpAuth::", 
+                "type": 8, 
+                "name": "HandleChallengeResponse", 
+                "text_range": {
+                  "start_line": 59, 
+                  "end_line": 90, 
+                  "start_column": 1, 
+                  "end_column": 2
+                }, 
+                "signature": "(HttpAuthHandler* handler, const HttpResponseHeaders& response_headers, Target target, const std::set<Scheme>& disabled_schemes, std::string* challenge_used)"
+              }, 
+              {
+                "name_prefix": "HttpAuth::", 
+                "type": 8, 
+                "name": "GetChallengeHeaderName", 
+                "text_range": {
+                  "start_line": 93, 
+                  "end_line": 103, 
+                  "start_column": 1, 
+                  "end_column": 2
+                }, 
+                "signature": "(Target target)"
+              }, 
+              {
+                "name_prefix": "HttpAuth::", 
+                "type": 8, 
+                "name": "GetAuthorizationHeaderName", 
+                "text_range": {
+                  "start_line": 106, 
+                  "end_line": 116, 
+                  "start_column": 1, 
+                  "end_column": 2
+                }, 
+                "signature": "(Target target)"
+              }, 
+              {
+                "name_prefix": "HttpAuth::", 
+                "type": 8, 
+                "name": "GetAuthTargetString", 
+                "text_range": {
+                  "start_line": 119, 
+                  "end_line": 129, 
+                  "start_column": 1, 
+                  "end_column": 2
+                }, 
+                "signature": "(Target target)"
+              }, 
+              {
+                "name_prefix": "HttpAuth::", 
+                "type": 8, 
+                "name": "SchemeToString", 
+                "text_range": {
+                  "start_line": 132, 
+                  "end_line": 143, 
+                  "start_column": 1, 
+                  "end_column": 2
+                }, 
+                "signature": "(Scheme scheme)"
+              }
+            ], 
+            "type": 11, 
+            "name": "net", 
+            "text_range": {
+              "start_line": 20, 
+              "end_line": 145, 
+              "start_column": 1, 
+              "end_column": 2
+            }, 
+            "signature": ""
+          }
+        ]
+      }, 
+      "return_code": 1
+    }
+  ]
+}

--- a/codesearch/testdata/responses/9a0702a4412a82f601c706b22045e62b671333f8.json
+++ b/codesearch/testdata/responses/9a0702a4412a82f601c706b22045e62b671333f8.json
@@ -1,0 +1,5599 @@
+{
+  "annotation_response": [
+    {
+      "return_code": 1, 
+      "annotation": [
+        {
+          "kythe_xref_kind": 600, 
+          "range": {
+            "start_line": 5, 
+            "end_line": 5, 
+            "start_column": 10, 
+            "end_column": 31
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {}, 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?path=src/net/http/http_auth.h"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 600, 
+          "range": {
+            "start_line": 7, 
+            "end_line": 7, 
+            "start_column": 10, 
+            "end_column": 20
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/algorithm", 
+            "range": {}, 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?path=src/buildtools/third_party/libc%2B%2B/trunk/include/algorithm"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 600, 
+          "range": {
+            "start_line": 9, 
+            "end_line": 9, 
+            "start_column": 10, 
+            "end_column": 42
+          }, 
+          "internal_link": {
+            "path": "src/base/strings/string_tokenizer.h", 
+            "range": {}, 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?path=src/base/strings/string_tokenizer.h"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 600, 
+          "range": {
+            "start_line": 10, 
+            "end_line": 10, 
+            "start_column": 10, 
+            "end_column": 37
+          }, 
+          "internal_link": {
+            "path": "src/base/strings/string_util.h", 
+            "range": {}, 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?path=src/base/strings/string_util.h"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 600, 
+          "range": {
+            "start_line": 11, 
+            "end_line": 11, 
+            "start_column": 10, 
+            "end_column": 32
+          }, 
+          "internal_link": {
+            "path": "src/net/base/net_errors.h", 
+            "range": {}, 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?path=src/net/base/net_errors.h"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 600, 
+          "range": {
+            "start_line": 12, 
+            "end_line": 12, 
+            "start_column": 10, 
+            "end_column": 51
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_challenge_tokenizer.h", 
+            "range": {}, 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?path=src/net/http/http_auth_challenge_tokenizer.h"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 600, 
+          "range": {
+            "start_line": 13, 
+            "end_line": 13, 
+            "start_column": 10, 
+            "end_column": 39
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_handler.h", 
+            "range": {}, 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?path=src/net/http/http_auth_handler.h"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 600, 
+          "range": {
+            "start_line": 14, 
+            "end_line": 14, 
+            "start_column": 10, 
+            "end_column": 47
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_handler_factory.h", 
+            "range": {}, 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?path=src/net/http/http_auth_handler_factory.h"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 600, 
+          "range": {
+            "start_line": 15, 
+            "end_line": 15, 
+            "start_column": 10, 
+            "end_column": 38
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_scheme.h", 
+            "range": {}, 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?path=src/net/http/http_auth_scheme.h"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 600, 
+          "range": {
+            "start_line": 16, 
+            "end_line": 16, 
+            "start_column": 10, 
+            "end_column": 42
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_request_headers.h", 
+            "range": {}, 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?path=src/net/http/http_request_headers.h"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 600, 
+          "range": {
+            "start_line": 17, 
+            "end_line": 17, 
+            "start_column": 10, 
+            "end_column": 43
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_response_headers.h", 
+            "range": {}, 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?path=src/net/http/http_response_headers.h"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 600, 
+          "range": {
+            "start_line": 18, 
+            "end_line": 18, 
+            "start_column": 10, 
+            "end_column": 31
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_util.h", 
+            "range": {}, 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?path=src/net/http/http_util.h"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 20, 
+            "end_line": 20, 
+            "start_column": 11, 
+            "end_column": 13
+          }, 
+          "kythe_xref_kind": 1200, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "signature": "kythe://chromium?lang=c%2B%2B#net%23n%23namespace"
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 22, 
+            "end_line": 22, 
+            "start_column": 1, 
+            "end_column": 8
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 27, 
+              "end_line": 27, 
+              "start_column": 26, 
+              "end_column": 33
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40621%3A629%40HttpAuth%3Anet%23c%23hUTvau_Z32C%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#HttpAuth%3Anet%23c%23hUTvau_Z32C"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1320, 
+          "range": {
+            "start_line": 22, 
+            "end_line": 22, 
+            "start_column": 11, 
+            "end_column": 18
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 103, 
+              "end_line": 103, 
+              "start_column": 10, 
+              "end_column": 17
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%403456%3A3464%40Identity%3AHttpAuth%3Anet%23c%23f6gF0FQkD9J%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#Identity%3AHttpAuth%3Anet%23c%23f6gF0FQkD9J"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 810, 
+          "range": {
+            "start_line": 22, 
+            "end_line": 22, 
+            "start_column": 21, 
+            "end_column": 28
+          }, 
+          "internal_link": {
+            "path": "src/net/base/auth.cc", 
+            "range": {
+              "start_line": 20, 
+              "end_line": 20, 
+              "start_column": 18, 
+              "end_column": 32
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/base/auth.cc#%40582%3A597%40OsAPDnCLZ1s5xMM5Ctlbver4ZIuwSiP3z4kEY91VETs%3D%23chromium%23src%2Fnet%2Fbase%2Fauth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/base/auth.h#zn%2F1%2FfmJ4QSZPRpYARw6hnISxkzFjfrssBx5TcUXMcQ%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1910, 
+          "range": {
+            "start_line": 22, 
+            "end_line": 22, 
+            "start_column": 34, 
+            "end_column": 39
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 106, 
+              "end_line": 106, 
+              "start_column": 20, 
+              "end_column": 25
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%403503%3A3509%40upC5AmKCx1TeHAb0k0jyg6WID4D6Rd3teS7bcNZedX8%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#upC5AmKCx1TeHAb0k0jyg6WID4D6Rd3teS7bcNZedX8%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 500, 
+          "range": {
+            "start_line": 22, 
+            "end_line": 22, 
+            "start_column": 41, 
+            "end_column": 54
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 68, 
+              "end_line": 68, 
+              "start_column": 5, 
+              "end_column": 18
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%402439%3A2453%40VM0IoK2CpoeCGuE8TGqD3NljtH%2F8qyZ7k0f3Nac7xoM%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#VM0IoK2CpoeCGuE8TGqD3NljtH%2F8qyZ7k0f3Nac7xoM%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1910, 
+          "range": {
+            "start_line": 22, 
+            "end_line": 22, 
+            "start_column": 58, 
+            "end_column": 64
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 107, 
+              "end_line": 107, 
+              "start_column": 10, 
+              "end_column": 16
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%403520%3A3527%40F9qBth0ivD4%2F%2FadAXZfr6Rp8AQ3n4r7rhQ0r%2FOU3jiY%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#F9qBth0ivD4%2F%2FadAXZfr6Rp8AQ3n4r7rhQ0r%2FOU3jiY%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 25, 
+            "end_line": 25, 
+            "start_column": 6, 
+            "end_column": 13
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 27, 
+              "end_line": 27, 
+              "start_column": 26, 
+              "end_column": 33
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40621%3A629%40HttpAuth%3Anet%23c%23hUTvau_Z32C%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#HttpAuth%3Anet%23c%23hUTvau_Z32C"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 26, 
+            "end_line": 26, 
+            "start_column": 5, 
+            "end_column": 26
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_handler_factory.h", 
+            "range": {
+              "start_line": 32, 
+              "end_line": 32, 
+              "start_column": 18, 
+              "end_column": 39
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler_factory.h#%40860%3A882%40HttpAuthHandlerFactory%3Anet%23c%23j%24O_zoH6ypw%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth_handler_factory.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler_factory.h#HttpAuthHandlerFactory%3Anet%23c%23j%24O_zoH6ypw"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 27, 
+            "end_line": 27, 
+            "start_column": 11, 
+            "end_column": 29
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_response_headers.h", 
+            "range": {
+              "start_line": 36, 
+              "end_line": 36, 
+              "start_column": 18, 
+              "end_column": 36
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_response_headers.h#%40799%3A818%40HttpResponseHeaders%3Anet%23c%23n1uMPuVNwlb%23chromium%23src%2Fnet%2Fhttp%2Fhttp_response_headers.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_response_headers.h#HttpResponseHeaders%3Anet%23c%23n1uMPuVNwlb"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 28, 
+            "end_line": 28, 
+            "start_column": 11, 
+            "end_column": 17
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 24, 
+              "end_line": 24, 
+              "start_column": 7, 
+              "end_column": 13
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40544%3A551%40Vn0U5bSgC%2FEU%2B8mC3MvGtXAA9o%2FE0KFwO%2FtMXSxwz%2FM%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#Vn0U5bSgC%2FEU%2B8mC3MvGtXAA9o%2FE0KFwO%2FtMXSxwz%2FM%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1410, 
+          "range": {
+            "start_line": 29, 
+            "end_line": 29, 
+            "start_column": 5, 
+            "end_column": 10
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 31, 
+              "end_line": 31, 
+              "start_column": 8, 
+              "end_column": 13
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40772%3A778%40Target%3AHttpAuth%3Anet%23n%23hMl2%24pd%24IrA%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#Target%3AHttpAuth%3Anet%23n%23hMl2%24pd%24IrA"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 30, 
+            "end_line": 30, 
+            "start_column": 11, 
+            "end_column": 14
+          }, 
+          "internal_link": {
+            "path": "src/url/gurl.h", 
+            "range": {
+              "start_line": 46, 
+              "end_line": 46, 
+              "start_column": 18, 
+              "end_column": 21
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/url/gurl.h#%401921%3A1925%40GURL%23c%23pEEsfrSEXKG%23chromium%23src%2Furl%2Fgurl.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/url/gurl.h#GURL%23c%23pEEsfrSEXKG"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 100, 
+          "range": {
+            "start_line": 31, 
+            "end_line": 31, 
+            "start_column": 16, 
+            "end_column": 18
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/set", 
+            "range": {
+              "start_line": 400, 
+              "end_line": 400, 
+              "start_column": 28, 
+              "end_column": 30
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/set#%4015582%3A15585%40IOMUvY06k4YSXsuMfRQAPeaf7jkksSQ4OBDLX42XnLc%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fset", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/set#IOMUvY06k4YSXsuMfRQAPeaf7jkksSQ4OBDLX42XnLc%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1410, 
+          "range": {
+            "start_line": 31, 
+            "end_line": 31, 
+            "start_column": 20, 
+            "end_column": 25
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 91, 
+              "end_line": 91, 
+              "start_column": 8, 
+              "end_column": 13
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%403144%3A3150%40Scheme%3AHttpAuth%3Anet%23n%23pQDbnWB0DcW%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#Scheme%3AHttpAuth%3Anet%23n%23pQDbnWB0DcW"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 32, 
+            "end_line": 32, 
+            "start_column": 11, 
+            "end_column": 26
+          }, 
+          "internal_link": {
+            "path": "src/net/log/net_log_with_source.h", 
+            "range": {
+              "start_line": 20, 
+              "end_line": 20, 
+              "start_column": 18, 
+              "end_column": 33
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/log/net_log_with_source.h#%40634%3A650%40NetLogWithSource%3Anet%23c%23oK541QlD9gC%23chromium%23src%2Fnet%2Flog%2Fnet_log_with_source.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/log/net_log_with_source.h#NetLogWithSource%3Anet%23c%23oK541QlD9gC"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 100, 
+          "range": {
+            "start_line": 33, 
+            "end_line": 33, 
+            "start_column": 10, 
+            "end_column": 19
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/memory", 
+            "range": {
+              "start_line": 2348, 
+              "end_line": 2348, 
+              "start_column": 28, 
+              "end_column": 37
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/memory#%4078534%3A78544%40%2FE9Ivnfha%2Fo2s4itBWveS3%2BZp%2F9HnNaIs2HPDigEjRg%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fmemory", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/memory#%2FE9Ivnfha%2Fo2s4itBWveS3%2BZp%2F9HnNaIs2HPDigEjRg%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 33, 
+            "end_line": 33, 
+            "start_column": 21, 
+            "end_column": 35
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_handler.h", 
+            "range": {
+              "start_line": 32, 
+              "end_line": 32, 
+              "start_column": 26, 
+              "end_column": 40
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler.h#%401073%3A1088%40HttpAuthHandler%3Anet%23c%23iu6yUDCVPqR%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth_handler.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler.h#HttpAuthHandler%3Anet%23c%23iu6yUDCVPqR"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1000, 
+          "range": {
+            "start_line": 34, 
+            "end_line": 34, 
+            "start_column": 3, 
+            "end_column": 8
+          }, 
+          "internal_link": {
+            "path": "src/base/logging.h", 
+            "range": {
+              "start_line": 858, 
+              "end_line": 858, 
+              "start_column": 9, 
+              "end_column": 14
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/base/logging.h#%4036034%3A36040%40DCHECK%23m%4036034%23chromium%23src%2Fbase%2Flogging.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/base/logging.h#DCHECK%23m%4036034"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 34, 
+            "end_line": 34, 
+            "start_column": 10, 
+            "end_column": 34
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 26, 
+              "end_line": 26, 
+              "start_column": 29, 
+              "end_column": 53
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%40804%3A829%40%2BPr0ofpYBwMJdsuwPQh2co4YkaKAf%2Fyu9Wo7bS3zNl4%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%2BPr0ofpYBwMJdsuwPQh2co4YkaKAf%2Fyu9Wo7bS3zNl4%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1000, 
+          "range": {
+            "start_line": 35, 
+            "end_line": 35, 
+            "start_column": 3, 
+            "end_column": 8
+          }, 
+          "internal_link": {
+            "path": "src/base/logging.h", 
+            "range": {
+              "start_line": 858, 
+              "end_line": 858, 
+              "start_column": 9, 
+              "end_column": 14
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/base/logging.h#%4036034%3A36040%40DCHECK%23m%4036034%23chromium%23src%2Fbase%2Flogging.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/base/logging.h#DCHECK%23m%4036034"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 35, 
+            "end_line": 35, 
+            "start_column": 10, 
+            "end_column": 16
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 33, 
+              "end_line": 33, 
+              "start_column": 39, 
+              "end_column": 45
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401073%3A1080%40AdDpcSmKLbTyOOqmkMLUpSJqw2avljg%2F85ZcuQ5RB1Q%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#AdDpcSmKLbTyOOqmkMLUpSJqw2avljg%2F85ZcuQ5RB1Q%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 35, 
+            "end_line": 35, 
+            "start_column": 19, 
+            "end_column": 21
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/memory", 
+            "range": {
+              "start_line": 2571, 
+              "end_line": 2571, 
+              "start_column": 11, 
+              "end_column": 13
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/memory#%4085966%3A85969%40ARcr%2FSj%2FQbFNSu4dQBWdFmjvil9NU6JOetdgfpb5x6k%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fmemory", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#AVkXPPnHhWuOGcD5hTqoWwr0fiOXTE%2F9VTp9HGDNwpQ%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1000, 
+          "range": {
+            "start_line": 35, 
+            "end_line": 35, 
+            "start_column": 28, 
+            "end_column": 31
+          }, 
+          "internal_link": {
+            "path": "kythe_builtins/include/stddef.h", 
+            "range": {
+              "start_line": 100, 
+              "end_line": 100, 
+              "start_column": 13, 
+              "end_column": 16
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=kythe_builtins/include/stddef.h#%403498%3A3502%40NULL%23m%403498%23chromium%23%2Fkythe_builtins%2Finclude%2Fstddef.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=kythe_builtins/include/stddef.h#NULL%23m%403498"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 100, 
+          "range": {
+            "start_line": 38, 
+            "end_line": 38, 
+            "start_column": 8, 
+            "end_column": 17
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/memory", 
+            "range": {
+              "start_line": 2348, 
+              "end_line": 2348, 
+              "start_column": 28, 
+              "end_column": 37
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/memory#%4078534%3A78544%40%2FE9Ivnfha%2Fo2s4itBWveS3%2BZp%2F9HnNaIs2HPDigEjRg%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fmemory", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/memory#%2FE9Ivnfha%2Fo2s4itBWveS3%2BZp%2F9HnNaIs2HPDigEjRg%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 38, 
+            "end_line": 38, 
+            "start_column": 19, 
+            "end_column": 33
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_handler.h", 
+            "range": {
+              "start_line": 32, 
+              "end_line": 32, 
+              "start_column": 26, 
+              "end_column": 40
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler.h#%401073%3A1088%40HttpAuthHandler%3Anet%23c%23iu6yUDCVPqR%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth_handler.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler.h#HttpAuthHandler%3Anet%23c%23iu6yUDCVPqR"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 38, 
+            "end_line": 38, 
+            "start_column": 36, 
+            "end_column": 39
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/memory", 
+            "range": {
+              "start_line": 2408, 
+              "end_line": 2408, 
+              "start_column": 13, 
+              "end_column": 22
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/memory#%4080571%3A80581%40OsIi%2F7C86iLOCSpzLhIWg9e6DWeGFqMBYo%2BjlW9H71Y%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fmemory", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#v10zIA9uQNcnyxVlc7z%2FjLXsxlO%2F54eK3QRPW%2BOokkU%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1500, 
+          "range": {
+            "start_line": 39, 
+            "end_line": 39, 
+            "start_column": 14, 
+            "end_column": 19
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/iosfwd", 
+            "range": {
+              "start_line": 194, 
+              "end_line": 194, 
+              "start_column": 65, 
+              "end_column": 70
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/iosfwd#%407594%3A7600%40Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 800, 
+          "range": {
+            "start_line": 39, 
+            "end_line": 39, 
+            "start_column": 35, 
+            "end_column": 56
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 93, 
+              "end_line": 93, 
+              "start_column": 23, 
+              "end_column": 44
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%403448%3A3470%40DRyCpVzYc1Hj4MuTTgDXCoXjPgyNLkegGhVqJJte51I%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#x%2FaEF9YHE1%2FkOulgnyTW%2BviGUGSqdYoRmRY%2FYC%2BN4Qo%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 39, 
+            "end_line": 39, 
+            "start_column": 58, 
+            "end_column": 63
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 29, 
+              "end_line": 29, 
+              "start_column": 12, 
+              "end_column": 17
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%40920%3A926%40wWGN9AvhGQmf3iv%2FpLgTpciDps9E9Wx0TjK6cuBfYgk%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#wWGN9AvhGQmf3iv%2FpLgTpciDps9E9Wx0TjK6cuBfYgk%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1500, 
+          "range": {
+            "start_line": 40, 
+            "end_line": 40, 
+            "start_column": 8, 
+            "end_column": 13
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/iosfwd", 
+            "range": {
+              "start_line": 194, 
+              "end_line": 194, 
+              "start_column": 65, 
+              "end_column": 70
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/iosfwd#%407594%3A7600%40Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 40, 
+            "end_line": 40, 
+            "start_column": 15, 
+            "end_column": 27
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/string", 
+            "range": {
+              "start_line": 1526, 
+              "end_line": 1526, 
+              "start_column": 44, 
+              "end_column": 55
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/string#%4063777%3A63789%406BQ2trbsw8KO74O0Nyevnz%2B10yc6%2BtQGaK2QR%2BHS%2B0k%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fstring", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#0yOUQwwFzFCv6rhzTgfAQnNMRn1d4dx%2BUKxXyzES6hg%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 41, 
+            "end_line": 41, 
+            "start_column": 3, 
+            "end_column": 8
+          }, 
+          "kythe_xref_kind": 1500, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "signature": "kythe:?lang=c%2B%2B#talias%28size_t%23n%2Cunsigned%20long%23builtin%29"
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 42, 
+            "end_line": 42, 
+            "start_column": 10, 
+            "end_column": 25
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 27, 
+              "end_line": 27, 
+              "start_column": 32, 
+              "end_column": 47
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%40862%3A878%40MCiey3DmeeSlo4BrqkK9ptuW2Zpcj%2BsQqLjEX%2BnznkE%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#MCiey3DmeeSlo4BrqkK9ptuW2Zpcj%2BsQqLjEX%2BnznkE%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 800, 
+          "range": {
+            "start_line": 42, 
+            "end_line": 42, 
+            "start_column": 27, 
+            "end_column": 41
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_response_headers.cc", 
+            "range": {
+              "start_line": 542, 
+              "end_line": 542, 
+              "start_column": 27, 
+              "end_column": 41
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_response_headers.cc#%4018267%3A18282%40y1p0vBvmKa9%2FdbQplydSYo85BOYF4A%2FjGHNnndTYmDo%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_response_headers.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_response_headers.h#pXPx7Xnp%2FxC60UIOVYw%2B0ORFjbVrkImGXi9GxdouwT0%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 42, 
+            "end_line": 42, 
+            "start_column": 44, 
+            "end_column": 47
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 41, 
+              "end_line": 41, 
+              "start_column": 10, 
+              "end_column": 13
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401381%3A1385%40%2BuD8Z59fY15SoBAM6qFZ0Mu4NFAsjO76Q9RetLyQITY%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%2BuD8Z59fY15SoBAM6qFZ0Mu4NFAsjO76Q9RetLyQITY%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 42, 
+            "end_line": 42, 
+            "start_column": 50, 
+            "end_column": 60
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 39, 
+              "end_line": 39, 
+              "start_column": 21, 
+              "end_column": 31
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401297%3A1308%40JGSyS9RLBbogLyKz1uB84cVIJnoETLnQVutdmXURFuY%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#JGSyS9RLBbogLyKz1uB84cVIJnoETLnQVutdmXURFuY%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 42, 
+            "end_line": 42, 
+            "start_column": 64, 
+            "end_column": 76
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 40, 
+              "end_line": 40, 
+              "start_column": 15, 
+              "end_column": 27
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401357%3A1370%40jJnDsLO60yQThw5YWPRzAc0pTfFV2cWIJedO3CKUI2M%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#jJnDsLO60yQThw5YWPRzAc0pTfFV2cWIJedO3CKUI2M%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 100, 
+          "range": {
+            "start_line": 43, 
+            "end_line": 43, 
+            "start_column": 10, 
+            "end_column": 19
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/memory", 
+            "range": {
+              "start_line": 2348, 
+              "end_line": 2348, 
+              "start_column": 28, 
+              "end_column": 37
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/memory#%4078534%3A78544%40%2FE9Ivnfha%2Fo2s4itBWveS3%2BZp%2F9HnNaIs2HPDigEjRg%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fmemory", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/memory#%2FE9Ivnfha%2Fo2s4itBWveS3%2BZp%2F9HnNaIs2HPDigEjRg%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 43, 
+            "end_line": 43, 
+            "start_column": 21, 
+            "end_column": 35
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_handler.h", 
+            "range": {
+              "start_line": 32, 
+              "end_line": 32, 
+              "start_column": 26, 
+              "end_column": 40
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler.h#%401073%3A1088%40HttpAuthHandler%3Anet%23c%23iu6yUDCVPqR%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth_handler.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler.h#HttpAuthHandler%3Anet%23c%23iu6yUDCVPqR"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 43, 
+            "end_line": 43, 
+            "start_column": 38, 
+            "end_column": 40
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/memory", 
+            "range": {
+              "start_line": 2408, 
+              "end_line": 2408, 
+              "start_column": 13, 
+              "end_column": 22
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/memory#%4080571%3A80581%40OsIi%2F7C86iLOCSpzLhIWg9e6DWeGFqMBYo%2BjlW9H71Y%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fmemory", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#v10zIA9uQNcnyxVlc7z%2FjLXsxlO%2F54eK3QRPW%2BOokkU%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 44, 
+            "end_line": 44, 
+            "start_column": 14, 
+            "end_column": 38
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 26, 
+              "end_line": 26, 
+              "start_column": 29, 
+              "end_column": 53
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%40804%3A829%40%2BPr0ofpYBwMJdsuwPQh2co4YkaKAf%2Fyu9Wo7bS3zNl4%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%2BPr0ofpYBwMJdsuwPQh2co4YkaKAf%2Fyu9Wo7bS3zNl4%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 800, 
+          "range": {
+            "start_line": 44, 
+            "end_line": 44, 
+            "start_column": 41, 
+            "end_column": 67
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_handler_factory.cc", 
+            "range": {
+              "start_line": 27, 
+              "end_line": 27, 
+              "start_column": 29, 
+              "end_column": 55
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler_factory.cc#%40855%3A882%406t3zvA8rmKdJQVvy%2Br4rs32m3n7rGrzRSbmPd%2FVzC78%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth_handler_factory.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler_factory.h#AhGbKTUY5zLXCJVN6z9Hcukqa1yLN5kfk5YywBcmREU%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 45, 
+            "end_line": 45, 
+            "start_column": 9, 
+            "end_column": 21
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 40, 
+              "end_line": 40, 
+              "start_column": 15, 
+              "end_column": 27
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401357%3A1370%40jJnDsLO60yQThw5YWPRzAc0pTfFV2cWIJedO3CKUI2M%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#jJnDsLO60yQThw5YWPRzAc0pTfFV2cWIJedO3CKUI2M%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 45, 
+            "end_line": 45, 
+            "start_column": 24, 
+            "end_column": 29
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 29, 
+              "end_line": 29, 
+              "start_column": 12, 
+              "end_column": 17
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%40920%3A926%40wWGN9AvhGQmf3iv%2FpLgTpciDps9E9Wx0TjK6cuBfYgk%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#wWGN9AvhGQmf3iv%2FpLgTpciDps9E9Wx0TjK6cuBfYgk%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 45, 
+            "end_line": 45, 
+            "start_column": 32, 
+            "end_column": 39
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 28, 
+              "end_line": 28, 
+              "start_column": 20, 
+              "end_column": 27
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%40899%3A907%40nrtZJ6eT%2BvMjiyaqLAfXyZn04AXm1j%2F2ElhPGm0g3Zg%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#nrtZJ6eT%2BvMjiyaqLAfXyZn04AXm1j%2F2ElhPGm0g3Zg%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 45, 
+            "end_line": 45, 
+            "start_column": 42, 
+            "end_column": 47
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 30, 
+              "end_line": 30, 
+              "start_column": 17, 
+              "end_column": 22
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%40944%3A950%40vOzjdpAmZc2RvaAvS3FzvN59FZ%2BE2%2B1FHQXTCkZBPLk%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#vOzjdpAmZc2RvaAvS3FzvN59FZ%2BE2%2B1FHQXTCkZBPLk%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 45, 
+            "end_line": 45, 
+            "start_column": 50, 
+            "end_column": 56
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 32, 
+              "end_line": 32, 
+              "start_column": 29, 
+              "end_column": 35
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401026%3A1033%40q7wXRjuHWNLRrTf06QFcNg6ghbJvypaBsGHf74AC5N8%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#q7wXRjuHWNLRrTf06QFcNg6ghbJvypaBsGHf74AC5N8%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 45, 
+            "end_line": 45, 
+            "start_column": 60, 
+            "end_column": 62
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 43, 
+              "end_line": 43, 
+              "start_column": 38, 
+              "end_column": 40
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401509%3A1512%409YGI9TmZyTlDu%2B20zsvrUzcNZoTZZ%2FSEjbCZACNgzkQ%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#9YGI9TmZyTlDu%2B20zsvrUzcNZoTZZ%2FSEjbCZACNgzkQ%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 46, 
+            "end_line": 46, 
+            "start_column": 9, 
+            "end_column": 10
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 44, 
+              "end_line": 44, 
+              "start_column": 9, 
+              "end_column": 10
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401522%3A1524%40ckCsolLifkGdY6OimJyejxWQQ4PX464tylv5M7%2FVxwk%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#ckCsolLifkGdY6OimJyejxWQQ4PX464tylv5M7%2FVxwk%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 500, 
+          "range": {
+            "start_line": 46, 
+            "end_line": 46, 
+            "start_column": 15, 
+            "end_column": 16
+          }, 
+          "internal_link": {
+            "path": "src/net/base/net_errors.h", 
+            "range": {
+              "start_line": 23, 
+              "end_line": 23, 
+              "start_column": 3, 
+              "end_column": 4
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/base/net_errors.h#%40533%3A535%40OK%3AError%3Anet%23n%23j6xO2ZfloFz%23chromium%23src%2Fnet%2Fbase%2Fnet_errors.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/base/net_errors.h#OK%3AError%3Anet%23n%23j6xO2ZfloFz"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1000, 
+          "range": {
+            "start_line": 47, 
+            "end_line": 47, 
+            "start_column": 7, 
+            "end_column": 10
+          }, 
+          "internal_link": {
+            "path": "src/base/logging.h", 
+            "range": {
+              "start_line": 428, 
+              "end_line": 428, 
+              "start_column": 9, 
+              "end_column": 12
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/base/logging.h#%4017619%3A17623%40VLOG%23m%4017619%23chromium%23src%2Fbase%2Flogging.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/base/logging.h#VLOG%23m%4017619"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 47, 
+            "end_line": 47, 
+            "start_column": 15, 
+            "end_column": 16
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/ostream", 
+            "range": {
+              "start_line": 862, 
+              "end_line": 862, 
+              "start_column": 1, 
+              "end_column": 10
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/ostream#%4026282%3A26292%40Vuf5zJqz3OA%2F9CwiUfo3Rwg2Dz%2BCsclDdtfP1Kxr8O8%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fostream", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#zuV0exYsZFmv5zCuZYaG5faqiqECjvqXzrNAYWsdqkg%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 48, 
+            "end_line": 48, 
+            "start_column": 15, 
+            "end_column": 16
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/ostream", 
+            "range": {
+              "start_line": 1044, 
+              "end_line": 1044, 
+              "start_column": 1, 
+              "end_column": 10
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/ostream#%4030725%3A30735%40aAoxAVtcy%2FTDAU9bMiMU83EqukJH0z9GWIBnrkFq3Nk%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fostream", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#vLzidtiADbCKrd7sANFEGrR9Bn56XcmEk%2Bxxxw%2BV03M%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 800, 
+          "range": {
+            "start_line": 48, 
+            "end_line": 48, 
+            "start_column": 18, 
+            "end_column": 30
+          }, 
+          "internal_link": {
+            "path": "src/net/base/net_errors.cc", 
+            "range": {
+              "start_line": 11, 
+              "end_line": 11, 
+              "start_column": 13, 
+              "end_column": 25
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/base/net_errors.cc#%40269%3A282%40IZ%2BvlQuPdqDoDxgkKFtSJ7G%2FGY%2BNTD%2Fj0cKzwXfSn%2BA%3D%23chromium%23src%2Fnet%2Fbase%2Fnet_errors.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/base/net_errors.h#9UaqXfHc4O5L1%2BDDHslWin1Bl6q8siKNARHkozutTdQ%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 48, 
+            "end_line": 48, 
+            "start_column": 32, 
+            "end_column": 33
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 44, 
+              "end_line": 44, 
+              "start_column": 9, 
+              "end_column": 10
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401522%3A1524%40ckCsolLifkGdY6OimJyejxWQQ4PX464tylv5M7%2FVxwk%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#ckCsolLifkGdY6OimJyejxWQQ4PX464tylv5M7%2FVxwk%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 48, 
+            "end_line": 48, 
+            "start_column": 36, 
+            "end_column": 37
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/ostream", 
+            "range": {
+              "start_line": 862, 
+              "end_line": 862, 
+              "start_column": 1, 
+              "end_column": 10
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/ostream#%4026282%3A26292%40Vuf5zJqz3OA%2F9CwiUfo3Rwg2Dz%2BCsclDdtfP1Kxr8O8%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fostream", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#zuV0exYsZFmv5zCuZYaG5faqiqECjvqXzrNAYWsdqkg%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 48, 
+            "end_line": 48, 
+            "start_column": 54, 
+            "end_column": 55
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/ostream", 
+            "range": {
+              "start_line": 1044, 
+              "end_line": 1044, 
+              "start_column": 1, 
+              "end_column": 10
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/ostream#%4030725%3A30735%40aAoxAVtcy%2FTDAU9bMiMU83EqukJH0z9GWIBnrkFq3Nk%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fostream", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#vLzidtiADbCKrd7sANFEGrR9Bn56XcmEk%2Bxxxw%2BV03M%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 48, 
+            "end_line": 48, 
+            "start_column": 57, 
+            "end_column": 69
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 40, 
+              "end_line": 40, 
+              "start_column": 15, 
+              "end_column": 27
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401357%3A1370%40jJnDsLO60yQThw5YWPRzAc0pTfFV2cWIJedO3CKUI2M%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#jJnDsLO60yQThw5YWPRzAc0pTfFV2cWIJedO3CKUI2M%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 51, 
+            "end_line": 51, 
+            "start_column": 9, 
+            "end_column": 11
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 43, 
+              "end_line": 43, 
+              "start_column": 38, 
+              "end_column": 40
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401509%3A1512%409YGI9TmZyTlDu%2B20zsvrUzcNZoTZZ%2FSEjbCZACNgzkQ%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#9YGI9TmZyTlDu%2B20zsvrUzcNZoTZZ%2FSEjbCZACNgzkQ%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 51, 
+            "end_line": 51, 
+            "start_column": 13, 
+            "end_column": 15
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/memory", 
+            "range": {
+              "start_line": 2571, 
+              "end_line": 2571, 
+              "start_column": 11, 
+              "end_column": 13
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/memory#%4085966%3A85969%40ARcr%2FSj%2FQbFNSu4dQBWdFmjvil9NU6JOetdgfpb5x6k%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fmemory", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#AVkXPPnHhWuOGcD5hTqoWwr0fiOXTE%2F9VTp9HGDNwpQ%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 51, 
+            "end_line": 51, 
+            "start_column": 24, 
+            "end_column": 27
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 38, 
+              "end_line": 38, 
+              "start_column": 36, 
+              "end_column": 39
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401271%3A1275%40Y1tkEBlo2BCaNFu%2BW0GyMZ4%2BYXInBcyF6hrR9CfeWj0%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#Y1tkEBlo2BCaNFu%2BW0GyMZ4%2BYXInBcyF6hrR9CfeWj0%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 51, 
+            "end_line": 51, 
+            "start_column": 29, 
+            "end_column": 31
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/memory", 
+            "range": {
+              "start_line": 2571, 
+              "end_line": 2571, 
+              "start_column": 11, 
+              "end_column": 13
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/memory#%4085966%3A85969%40ARcr%2FSj%2FQbFNSu4dQBWdFmjvil9NU6JOetdgfpb5x6k%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fmemory", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#AVkXPPnHhWuOGcD5hTqoWwr0fiOXTE%2F9VTp9HGDNwpQ%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 51, 
+            "end_line": 51, 
+            "start_column": 38, 
+            "end_column": 41
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 38, 
+              "end_line": 38, 
+              "start_column": 36, 
+              "end_column": 39
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401271%3A1275%40Y1tkEBlo2BCaNFu%2BW0GyMZ4%2BYXInBcyF6hrR9CfeWj0%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#Y1tkEBlo2BCaNFu%2BW0GyMZ4%2BYXInBcyF6hrR9CfeWj0%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 51, 
+            "end_line": 51, 
+            "start_column": 42, 
+            "end_column": 43
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/memory", 
+            "range": {
+              "start_line": 2567, 
+              "end_line": 2567, 
+              "start_column": 11, 
+              "end_column": 20
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/memory#%4085866%3A85876%40CWhFfoh7qssk2dh68d9LBTgvepq6ZxzyUUigl1c8BrQ%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fmemory", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#IgJXSeDkXqk7wdtJqv%2B8kb%2Frn%2F8ZhcsArrrefT8Qs0A%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 800, 
+          "range": {
+            "start_line": 51, 
+            "end_line": 51, 
+            "start_column": 44, 
+            "end_column": 48
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_handler.h", 
+            "range": {
+              "start_line": 104, 
+              "end_line": 104, 
+              "start_column": 7, 
+              "end_column": 11
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler.h#%404279%3A4284%40vdjm%2FbUesHw9yawRarJuXHeGOdYePW6mSBKjruPk0a4%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth_handler.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler.h#vdjm%2FbUesHw9yawRarJuXHeGOdYePW6mSBKjruPk0a4%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 51, 
+            "end_line": 51, 
+            "start_column": 54, 
+            "end_column": 56
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 43, 
+              "end_line": 43, 
+              "start_column": 38, 
+              "end_column": 40
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401509%3A1512%409YGI9TmZyTlDu%2B20zsvrUzcNZoTZZ%2FSEjbCZACNgzkQ%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#9YGI9TmZyTlDu%2B20zsvrUzcNZoTZZ%2FSEjbCZACNgzkQ%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 51, 
+            "end_line": 51, 
+            "start_column": 57, 
+            "end_column": 58
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/memory", 
+            "range": {
+              "start_line": 2567, 
+              "end_line": 2567, 
+              "start_column": 11, 
+              "end_column": 20
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/memory#%4085866%3A85876%40CWhFfoh7qssk2dh68d9LBTgvepq6ZxzyUUigl1c8BrQ%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fmemory", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#IgJXSeDkXqk7wdtJqv%2B8kb%2Frn%2F8ZhcsArrrefT8Qs0A%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 800, 
+          "range": {
+            "start_line": 51, 
+            "end_line": 51, 
+            "start_column": 59, 
+            "end_column": 63
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_handler.h", 
+            "range": {
+              "start_line": 104, 
+              "end_line": 104, 
+              "start_column": 7, 
+              "end_column": 11
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler.h#%404279%3A4284%40vdjm%2FbUesHw9yawRarJuXHeGOdYePW6mSBKjruPk0a4%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth_handler.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler.h#vdjm%2FbUesHw9yawRarJuXHeGOdYePW6mSBKjruPk0a4%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 52, 
+            "end_line": 52, 
+            "start_column": 10, 
+            "end_column": 25
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 31, 
+              "end_line": 31, 
+              "start_column": 29, 
+              "end_column": 44
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%40980%3A996%40rRrbLmhqydZdc2uyX%2FKCvn%2F7ZRu%2FgPeicu6Wq9ZWRSs%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#rRrbLmhqydZdc2uyX%2FKCvn%2F7ZRu%2FgPeicu6Wq9ZWRSs%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 52, 
+            "end_line": 52, 
+            "start_column": 27, 
+            "end_column": 30
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/set", 
+            "range": {
+              "start_line": 652, 
+              "end_line": 652, 
+              "start_column": 20, 
+              "end_column": 23
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/set#%4024633%3A24637%40eaO8%2FUi7tPKrF7CqRwfB7ILDiSBMUBTkn75DSW8%2Fras%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fset", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#eumriqDCa4dOr%2Bf37pFhGioTjqEIxPb4ozmhnk0nOTA%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 52, 
+            "end_line": 52, 
+            "start_column": 32, 
+            "end_column": 34
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 43, 
+              "end_line": 43, 
+              "start_column": 38, 
+              "end_column": 40
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401509%3A1512%409YGI9TmZyTlDu%2B20zsvrUzcNZoTZZ%2FSEjbCZACNgzkQ%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#9YGI9TmZyTlDu%2B20zsvrUzcNZoTZZ%2FSEjbCZACNgzkQ%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 52, 
+            "end_line": 52, 
+            "start_column": 35, 
+            "end_column": 36
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/memory", 
+            "range": {
+              "start_line": 2567, 
+              "end_line": 2567, 
+              "start_column": 11, 
+              "end_column": 20
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/memory#%4085866%3A85876%40CWhFfoh7qssk2dh68d9LBTgvepq6ZxzyUUigl1c8BrQ%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fmemory", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#IgJXSeDkXqk7wdtJqv%2B8kb%2Frn%2F8ZhcsArrrefT8Qs0A%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 800, 
+          "range": {
+            "start_line": 52, 
+            "end_line": 52, 
+            "start_column": 37, 
+            "end_column": 47
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_handler.h", 
+            "range": {
+              "start_line": 90, 
+              "end_line": 90, 
+              "start_column": 20, 
+              "end_column": 30
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler.h#%403844%3A3855%40%2B3vBTjOB9MHPhjI9%2FejuqucNaANApwdhube9IuO4Ngs%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth_handler.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler.h#%2B3vBTjOB9MHPhjI9%2FejuqucNaANApwdhube9IuO4Ngs%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 52, 
+            "end_line": 52, 
+            "start_column": 52, 
+            "end_column": 53
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/__tree", 
+            "range": {
+              "start_line": 941, 
+              "end_line": 941, 
+              "start_column": 14, 
+              "end_column": 23
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/__tree#%4034442%3A34452%405JfZMQE6ZqXvvwYQULeVU0kq71NM7y30sBxhrTy1qvM%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2F__tree", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#9PrJc1ICLSJiuJ4ci3MzM4s9T%2BCzNyJP2PWMyy9VHW4%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 52, 
+            "end_line": 52, 
+            "start_column": 55, 
+            "end_column": 70
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 31, 
+              "end_line": 31, 
+              "start_column": 29, 
+              "end_column": 44
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%40980%3A996%40rRrbLmhqydZdc2uyX%2FKCvn%2F7ZRu%2FgPeicu6Wq9ZWRSs%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#rRrbLmhqydZdc2uyX%2FKCvn%2F7ZRu%2FgPeicu6Wq9ZWRSs%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 52, 
+            "end_line": 52, 
+            "start_column": 72, 
+            "end_column": 74
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/set", 
+            "range": {
+              "start_line": 554, 
+              "end_line": 554, 
+              "start_column": 20, 
+              "end_column": 22
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/set#%4020796%3A20799%401Rhm3DBZqvE55hLSdSESXJ4DlyHHJe3oCd1XzdW4pPQ%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fset", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#FFSFt5%2BSrpq4WOh3cAaX%2FjBFXcogtmQOxyhnOt6L0Vg%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 53, 
+            "end_line": 53, 
+            "start_column": 7, 
+            "end_column": 10
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 38, 
+              "end_line": 38, 
+              "start_column": 36, 
+              "end_column": 39
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401271%3A1275%40Y1tkEBlo2BCaNFu%2BW0GyMZ4%2BYXInBcyF6hrR9CfeWj0%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#Y1tkEBlo2BCaNFu%2BW0GyMZ4%2BYXInBcyF6hrR9CfeWj0%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 53, 
+            "end_line": 53, 
+            "start_column": 12, 
+            "end_column": 15
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/memory", 
+            "range": {
+              "start_line": 2603, 
+              "end_line": 2603, 
+              "start_column": 8, 
+              "end_column": 11
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/memory#%4086733%3A86737%40YMffxGRmSgg%2BUbsJLcNRolaDuijQBRLspXjYog%2F9vg4%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fmemory", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#rlYld0GFH7mpQnPLr866o%2Fos5kPeeey43cnv0C62D9Q%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 53, 
+            "end_line": 53, 
+            "start_column": 17, 
+            "end_column": 19
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 43, 
+              "end_line": 43, 
+              "start_column": 38, 
+              "end_column": 40
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401509%3A1512%409YGI9TmZyTlDu%2B20zsvrUzcNZoTZZ%2FSEjbCZACNgzkQ%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#9YGI9TmZyTlDu%2B20zsvrUzcNZoTZZ%2FSEjbCZACNgzkQ%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 55, 
+            "end_line": 55, 
+            "start_column": 3, 
+            "end_column": 9
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 33, 
+              "end_line": 33, 
+              "start_column": 39, 
+              "end_column": 45
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401073%3A1080%40AdDpcSmKLbTyOOqmkMLUpSJqw2avljg%2F85ZcuQ5RB1Q%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#AdDpcSmKLbTyOOqmkMLUpSJqw2avljg%2F85ZcuQ5RB1Q%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 55, 
+            "end_line": 55, 
+            "start_column": 12, 
+            "end_column": 15
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/memory", 
+            "range": {
+              "start_line": 2603, 
+              "end_line": 2603, 
+              "start_column": 8, 
+              "end_column": 11
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/memory#%4086733%3A86737%40YMffxGRmSgg%2BUbsJLcNRolaDuijQBRLspXjYog%2F9vg4%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fmemory", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#rlYld0GFH7mpQnPLr866o%2Fos5kPeeey43cnv0C62D9Q%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 55, 
+            "end_line": 55, 
+            "start_column": 17, 
+            "end_column": 20
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 38, 
+              "end_line": 38, 
+              "start_column": 36, 
+              "end_column": 39
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401271%3A1275%40Y1tkEBlo2BCaNFu%2BW0GyMZ4%2BYXInBcyF6hrR9CfeWj0%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#Y1tkEBlo2BCaNFu%2BW0GyMZ4%2BYXInBcyF6hrR9CfeWj0%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 59, 
+            "end_line": 59, 
+            "start_column": 1, 
+            "end_column": 8
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 27, 
+              "end_line": 27, 
+              "start_column": 26, 
+              "end_column": 33
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40621%3A629%40HttpAuth%3Anet%23c%23hUTvau_Z32C%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#HttpAuth%3Anet%23c%23hUTvau_Z32C"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1410, 
+          "range": {
+            "start_line": 59, 
+            "end_line": 59, 
+            "start_column": 11, 
+            "end_column": 29
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 42, 
+              "end_line": 42, 
+              "start_column": 8, 
+              "end_column": 26
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%401114%3A1133%40xvt9k4Unkv8WLBCKdsdmO0dfqTpkUpxSHZKr2e5MPxo%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#xvt9k4Unkv8WLBCKdsdmO0dfqTpkUpxSHZKr2e5MPxo%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 59, 
+            "end_line": 59, 
+            "start_column": 31, 
+            "end_column": 38
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 27, 
+              "end_line": 27, 
+              "start_column": 26, 
+              "end_column": 33
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40621%3A629%40HttpAuth%3Anet%23c%23hUTvau_Z32C%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#HttpAuth%3Anet%23c%23hUTvau_Z32C"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 60, 
+            "end_line": 60, 
+            "start_column": 5, 
+            "end_column": 19
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_handler.h", 
+            "range": {
+              "start_line": 32, 
+              "end_line": 32, 
+              "start_column": 26, 
+              "end_column": 40
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler.h#%401073%3A1088%40HttpAuthHandler%3Anet%23c%23iu6yUDCVPqR%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth_handler.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler.h#HttpAuthHandler%3Anet%23c%23iu6yUDCVPqR"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 61, 
+            "end_line": 61, 
+            "start_column": 11, 
+            "end_column": 29
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_response_headers.h", 
+            "range": {
+              "start_line": 36, 
+              "end_line": 36, 
+              "start_column": 18, 
+              "end_column": 36
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_response_headers.h#%40799%3A818%40HttpResponseHeaders%3Anet%23c%23n1uMPuVNwlb%23chromium%23src%2Fnet%2Fhttp%2Fhttp_response_headers.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_response_headers.h#HttpResponseHeaders%3Anet%23c%23n1uMPuVNwlb"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1410, 
+          "range": {
+            "start_line": 62, 
+            "end_line": 62, 
+            "start_column": 5, 
+            "end_column": 10
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 31, 
+              "end_line": 31, 
+              "start_column": 8, 
+              "end_column": 13
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40772%3A778%40Target%3AHttpAuth%3Anet%23n%23hMl2%24pd%24IrA%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#Target%3AHttpAuth%3Anet%23n%23hMl2%24pd%24IrA"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 100, 
+          "range": {
+            "start_line": 63, 
+            "end_line": 63, 
+            "start_column": 16, 
+            "end_column": 18
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/set", 
+            "range": {
+              "start_line": 400, 
+              "end_line": 400, 
+              "start_column": 28, 
+              "end_column": 30
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/set#%4015582%3A15585%40IOMUvY06k4YSXsuMfRQAPeaf7jkksSQ4OBDLX42XnLc%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fset", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/set#IOMUvY06k4YSXsuMfRQAPeaf7jkksSQ4OBDLX42XnLc%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1410, 
+          "range": {
+            "start_line": 63, 
+            "end_line": 63, 
+            "start_column": 20, 
+            "end_column": 25
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 91, 
+              "end_line": 91, 
+              "start_column": 8, 
+              "end_column": 13
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%403144%3A3150%40Scheme%3AHttpAuth%3Anet%23n%23pQDbnWB0DcW%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#Scheme%3AHttpAuth%3Anet%23n%23pQDbnWB0DcW"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1500, 
+          "range": {
+            "start_line": 64, 
+            "end_line": 64, 
+            "start_column": 10, 
+            "end_column": 15
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/iosfwd", 
+            "range": {
+              "start_line": 194, 
+              "end_line": 194, 
+              "start_column": 65, 
+              "end_column": 70
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/iosfwd#%407594%3A7600%40Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1000, 
+          "range": {
+            "start_line": 65, 
+            "end_line": 65, 
+            "start_column": 3, 
+            "end_column": 8
+          }, 
+          "internal_link": {
+            "path": "src/base/logging.h", 
+            "range": {
+              "start_line": 858, 
+              "end_line": 858, 
+              "start_column": 9, 
+              "end_column": 14
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/base/logging.h#%4036034%3A36040%40DCHECK%23m%4036034%23chromium%23src%2Fbase%2Flogging.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/base/logging.h#DCHECK%23m%4036034"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 65, 
+            "end_line": 65, 
+            "start_column": 10, 
+            "end_column": 16
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 60, 
+              "end_line": 60, 
+              "start_column": 22, 
+              "end_column": 28
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402116%3A2123%40Ok4LgjzuSDZDBkmjk%2FuyWT2yWuTJAX9bGoeZHVBYAY4%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#Ok4LgjzuSDZDBkmjk%2FuyWT2yWuTJAX9bGoeZHVBYAY4%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1000, 
+          "range": {
+            "start_line": 66, 
+            "end_line": 66, 
+            "start_column": 3, 
+            "end_column": 8
+          }, 
+          "internal_link": {
+            "path": "src/base/logging.h", 
+            "range": {
+              "start_line": 858, 
+              "end_line": 858, 
+              "start_column": 9, 
+              "end_column": 14
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/base/logging.h#%4036034%3A36040%40DCHECK%23m%4036034%23chromium%23src%2Fbase%2Flogging.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/base/logging.h#DCHECK%23m%4036034"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 66, 
+            "end_line": 66, 
+            "start_column": 10, 
+            "end_column": 23
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 64, 
+              "end_line": 64, 
+              "start_column": 18, 
+              "end_column": 31
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402256%3A2270%40dW4FIpXZfUwQqx6bJisQbr80WGjMR4j0gGOOHAOj6ME%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#dW4FIpXZfUwQqx6bJisQbr80WGjMR4j0gGOOHAOj6ME%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 67, 
+            "end_line": 67, 
+            "start_column": 3, 
+            "end_column": 16
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 64, 
+              "end_line": 64, 
+              "start_column": 18, 
+              "end_column": 31
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402256%3A2270%40dW4FIpXZfUwQqx6bJisQbr80WGjMR4j0gGOOHAOj6ME%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#dW4FIpXZfUwQqx6bJisQbr80WGjMR4j0gGOOHAOj6ME%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 67, 
+            "end_line": 67, 
+            "start_column": 19, 
+            "end_column": 23
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/string", 
+            "range": {
+              "start_line": 2857, 
+              "end_line": 2857, 
+              "start_column": 44, 
+              "end_column": 48
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/string#%40108806%3A108811%40EI6%2BA3B8iUdMY828CbGbrJMhEpLoWlnhFuLNvM32ods%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fstring", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#BmGHAwmOXWKk7sHJ0sXptWbfvYRNVejLILcsyK6O3cs%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 68, 
+            "end_line": 68, 
+            "start_column": 3, 
+            "end_column": 10
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 27, 
+              "end_line": 27, 
+              "start_column": 26, 
+              "end_column": 33
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40621%3A629%40HttpAuth%3Anet%23c%23hUTvau_Z32C%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#HttpAuth%3Anet%23c%23hUTvau_Z32C"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1410, 
+          "range": {
+            "start_line": 68, 
+            "end_line": 68, 
+            "start_column": 13, 
+            "end_column": 18
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 91, 
+              "end_line": 91, 
+              "start_column": 8, 
+              "end_column": 13
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%403144%3A3150%40Scheme%3AHttpAuth%3Anet%23n%23pQDbnWB0DcW%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#Scheme%3AHttpAuth%3Anet%23n%23pQDbnWB0DcW"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 68, 
+            "end_line": 68, 
+            "start_column": 37, 
+            "end_column": 43
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 60, 
+              "end_line": 60, 
+              "start_column": 22, 
+              "end_column": 28
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402116%3A2123%40Ok4LgjzuSDZDBkmjk%2FuyWT2yWuTJAX9bGoeZHVBYAY4%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#Ok4LgjzuSDZDBkmjk%2FuyWT2yWuTJAX9bGoeZHVBYAY4%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 800, 
+          "range": {
+            "start_line": 68, 
+            "end_line": 68, 
+            "start_column": 46, 
+            "end_column": 56
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_handler.h", 
+            "range": {
+              "start_line": 90, 
+              "end_line": 90, 
+              "start_column": 20, 
+              "end_column": 30
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler.h#%403844%3A3855%40%2B3vBTjOB9MHPhjI9%2FejuqucNaANApwdhube9IuO4Ngs%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth_handler.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler.h#%2B3vBTjOB9MHPhjI9%2FejuqucNaANApwdhube9IuO4Ngs%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 69, 
+            "end_line": 69, 
+            "start_column": 7, 
+            "end_column": 22
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 63, 
+              "end_line": 63, 
+              "start_column": 29, 
+              "end_column": 44
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402221%3A2237%40ombJf5xJ%2Fn3IpCOjANPsrnUsf5VLpZriLEuIh3kQf74%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#ombJf5xJ%2Fn3IpCOjANPsrnUsf5VLpZriLEuIh3kQf74%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 69, 
+            "end_line": 69, 
+            "start_column": 24, 
+            "end_column": 27
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/set", 
+            "range": {
+              "start_line": 652, 
+              "end_line": 652, 
+              "start_column": 20, 
+              "end_column": 23
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/set#%4024633%3A24637%40eaO8%2FUi7tPKrF7CqRwfB7ILDiSBMUBTkn75DSW8%2Fras%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fset", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#eumriqDCa4dOr%2Bf37pFhGioTjqEIxPb4ozmhnk0nOTA%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 69, 
+            "end_line": 69, 
+            "start_column": 29, 
+            "end_column": 42
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 68, 
+              "end_line": 68, 
+              "start_column": 20, 
+              "end_column": 33
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402365%3A2379%40Aqah1wrC%2FCkVahDI2ljrB5B7fqlpLH3Id8r6D4sjEYs%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#Aqah1wrC%2FCkVahDI2ljrB5B7fqlpLH3Id8r6D4sjEYs%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 69, 
+            "end_line": 69, 
+            "start_column": 45, 
+            "end_column": 46
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/__tree", 
+            "range": {
+              "start_line": 944, 
+              "end_line": 944, 
+              "start_column": 14, 
+              "end_column": 23
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/__tree#%4034614%3A34624%40Twai2PncRBIPZgr4aiKCF0vJbpTHm%2Fa7U%2FG%2FV03MZug%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2F__tree", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#vfD4RxFLoEQ64S9eul1pYebx0tdoK5PaserTGJRSpus%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 69, 
+            "end_line": 69, 
+            "start_column": 48, 
+            "end_column": 63
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 63, 
+              "end_line": 63, 
+              "start_column": 29, 
+              "end_column": 44
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402221%3A2237%40ombJf5xJ%2Fn3IpCOjANPsrnUsf5VLpZriLEuIh3kQf74%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#ombJf5xJ%2Fn3IpCOjANPsrnUsf5VLpZriLEuIh3kQf74%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 69, 
+            "end_line": 69, 
+            "start_column": 65, 
+            "end_column": 67
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/set", 
+            "range": {
+              "start_line": 554, 
+              "end_line": 554, 
+              "start_column": 20, 
+              "end_column": 22
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/set#%4020796%3A20799%401Rhm3DBZqvE55hLSdSESXJ4DlyHHJe3oCd1XzdW4pPQ%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fset", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#FFSFt5%2BSrpq4WOh3cAaX%2FjBFXcogtmQOxyhnOt6L0Vg%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 70, 
+            "end_line": 70, 
+            "start_column": 12, 
+            "end_column": 19
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 27, 
+              "end_line": 27, 
+              "start_column": 26, 
+              "end_column": 33
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40621%3A629%40HttpAuth%3Anet%23c%23hUTvau_Z32C%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#HttpAuth%3Anet%23c%23hUTvau_Z32C"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 500, 
+          "range": {
+            "start_line": 70, 
+            "end_line": 70, 
+            "start_column": 22, 
+            "end_column": 48
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 47, 
+              "end_line": 47, 
+              "start_column": 5, 
+              "end_column": 31
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%401356%3A1383%40%2Bzs8xzJ1yfOYD7Mv08TfZHC2vceSbgzdy2f6x6MPRIc%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%2Bzs8xzJ1yfOYD7Mv08TfZHC2vceSbgzdy2f6x6MPRIc%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1500, 
+          "range": {
+            "start_line": 71, 
+            "end_line": 71, 
+            "start_column": 8, 
+            "end_column": 13
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/iosfwd", 
+            "range": {
+              "start_line": 194, 
+              "end_line": 194, 
+              "start_column": 65, 
+              "end_column": 70
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/iosfwd#%407594%3A7600%40Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 800, 
+          "range": {
+            "start_line": 71, 
+            "end_line": 71, 
+            "start_column": 37, 
+            "end_column": 50
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 132, 
+              "end_line": 132, 
+              "start_column": 23, 
+              "end_column": 36
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%404274%3A4288%40%2Fb%2BRIOVl8o6nlI1otAdGcLGZTqbEJ5i6AOQiav6%2BhI0%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#chyBhicIO3mDeVdyiHuBrkroZhFBUqza9v0SxS4aCbk%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 71, 
+            "end_line": 71, 
+            "start_column": 52, 
+            "end_column": 65
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 68, 
+              "end_line": 68, 
+              "start_column": 20, 
+              "end_column": 33
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402365%3A2379%40Aqah1wrC%2FCkVahDI2ljrB5B7fqlpLH3Id8r6D4sjEYs%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#Aqah1wrC%2FCkVahDI2ljrB5B7fqlpLH3Id8r6D4sjEYs%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1500, 
+          "range": {
+            "start_line": 72, 
+            "end_line": 72, 
+            "start_column": 14, 
+            "end_column": 19
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/iosfwd", 
+            "range": {
+              "start_line": 194, 
+              "end_line": 194, 
+              "start_column": 65, 
+              "end_column": 70
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/iosfwd#%407594%3A7600%40Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 800, 
+          "range": {
+            "start_line": 72, 
+            "end_line": 72, 
+            "start_column": 35, 
+            "end_column": 56
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 93, 
+              "end_line": 93, 
+              "start_column": 23, 
+              "end_column": 44
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%403448%3A3470%40DRyCpVzYc1Hj4MuTTgDXCoXjPgyNLkegGhVqJJte51I%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#x%2FaEF9YHE1%2FkOulgnyTW%2BviGUGSqdYoRmRY%2FYC%2BN4Qo%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 72, 
+            "end_line": 72, 
+            "start_column": 58, 
+            "end_column": 63
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 62, 
+              "end_line": 62, 
+              "start_column": 12, 
+              "end_column": 17
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402185%3A2191%40zQWSOtka6iEjrC%2F6YiKlFXwlxonuHGKyT8D8RK5v2hw%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#zQWSOtka6iEjrC%2F6YiKlFXwlxonuHGKyT8D8RK5v2hw%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 73, 
+            "end_line": 73, 
+            "start_column": 3, 
+            "end_column": 8
+          }, 
+          "kythe_xref_kind": 1500, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "signature": "kythe:?lang=c%2B%2B#talias%28size_t%23n%2Cunsigned%20long%23builtin%29"
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1500, 
+          "range": {
+            "start_line": 74, 
+            "end_line": 74, 
+            "start_column": 8, 
+            "end_column": 13
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/iosfwd", 
+            "range": {
+              "start_line": 194, 
+              "end_line": 194, 
+              "start_column": 65, 
+              "end_column": 70
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/iosfwd#%407594%3A7600%40Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 74, 
+            "end_line": 74, 
+            "start_column": 15, 
+            "end_column": 23
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/string", 
+            "range": {
+              "start_line": 1526, 
+              "end_line": 1526, 
+              "start_column": 44, 
+              "end_column": 55
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/string#%4063777%3A63789%406BQ2trbsw8KO74O0Nyevnz%2B10yc6%2BtQGaK2QR%2BHS%2B0k%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fstring", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#0yOUQwwFzFCv6rhzTgfAQnNMRn1d4dx%2BUKxXyzES6hg%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 75, 
+            "end_line": 75, 
+            "start_column": 3, 
+            "end_column": 10
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 27, 
+              "end_line": 27, 
+              "start_column": 26, 
+              "end_column": 33
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40621%3A629%40HttpAuth%3Anet%23c%23hUTvau_Z32C%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#HttpAuth%3Anet%23c%23hUTvau_Z32C"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1410, 
+          "range": {
+            "start_line": 75, 
+            "end_line": 75, 
+            "start_column": 13, 
+            "end_column": 31
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 42, 
+              "end_line": 42, 
+              "start_column": 8, 
+              "end_column": 26
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%401114%3A1133%40xvt9k4Unkv8WLBCKdsdmO0dfqTpkUpxSHZKr2e5MPxo%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#xvt9k4Unkv8WLBCKdsdmO0dfqTpkUpxSHZKr2e5MPxo%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 76, 
+            "end_line": 76, 
+            "start_column": 7, 
+            "end_column": 14
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 27, 
+              "end_line": 27, 
+              "start_column": 26, 
+              "end_column": 33
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40621%3A629%40HttpAuth%3Anet%23c%23hUTvau_Z32C%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#HttpAuth%3Anet%23c%23hUTvau_Z32C"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 500, 
+          "range": {
+            "start_line": 76, 
+            "end_line": 76, 
+            "start_column": 17, 
+            "end_column": 44
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 53, 
+              "end_line": 53, 
+              "start_column": 5, 
+              "end_column": 32
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%401650%3A1678%40z%2BvaKuoWNRlPlv8ZBtk%2F2KWczFfDYiDqR15Q0zBMhJI%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#z%2BvaKuoWNRlPlv8ZBtk%2F2KWczFfDYiDqR15Q0zBMhJI%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 77, 
+            "end_line": 77, 
+            "start_column": 10, 
+            "end_column": 25
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 61, 
+              "end_line": 61, 
+              "start_column": 32, 
+              "end_column": 47
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402156%3A2172%40b56hUwpTTye5qHFZRHyIkaDNpb2Hknzksp6pdky8VqM%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#b56hUwpTTye5qHFZRHyIkaDNpb2Hknzksp6pdky8VqM%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 800, 
+          "range": {
+            "start_line": 77, 
+            "end_line": 77, 
+            "start_column": 27, 
+            "end_column": 41
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_response_headers.cc", 
+            "range": {
+              "start_line": 542, 
+              "end_line": 542, 
+              "start_column": 27, 
+              "end_column": 41
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_response_headers.cc#%4018267%3A18282%40y1p0vBvmKa9%2FdbQplydSYo85BOYF4A%2FjGHNnndTYmDo%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_response_headers.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_response_headers.h#pXPx7Xnp%2FxC60UIOVYw%2B0ORFjbVrkImGXi9GxdouwT0%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 77, 
+            "end_line": 77, 
+            "start_column": 44, 
+            "end_column": 47
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 73, 
+              "end_line": 73, 
+              "start_column": 10, 
+              "end_column": 13
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402670%3A2674%40dwWzcX%2Fw1baerdEqIUuAndlRLmhvuFBl5M8cx57qhkE%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#dwWzcX%2Fw1baerdEqIUuAndlRLmhvuFBl5M8cx57qhkE%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 77, 
+            "end_line": 77, 
+            "start_column": 50, 
+            "end_column": 60
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 72, 
+              "end_line": 72, 
+              "start_column": 21, 
+              "end_column": 31
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402615%3A2626%40gpiJ92vk3ysmqLRN5LF62wME9MjLdQIxaLAQfSbVMaE%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#gpiJ92vk3ysmqLRN5LF62wME9MjLdQIxaLAQfSbVMaE%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 77, 
+            "end_line": 77, 
+            "start_column": 64, 
+            "end_column": 72
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 74, 
+              "end_line": 74, 
+              "start_column": 15, 
+              "end_column": 23
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402694%3A2703%40%2FZarsaZ0yht4g9p%2BVPvibKVgNDCj8UGk3%2BP1otnH1eU%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%2FZarsaZ0yht4g9p%2BVPvibKVgNDCj8UGk3%2BP1otnH1eU%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 78, 
+            "end_line": 78, 
+            "start_column": 5, 
+            "end_column": 30
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_challenge_tokenizer.h", 
+            "range": {
+              "start_line": 23, 
+              "end_line": 23, 
+              "start_column": 26, 
+              "end_column": 51
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_challenge_tokenizer.h#%40815%3A841%40kjEvEnCJ9C%2By8r6dA7WBCh4pigdrfc4vNGN1cB9bnf0%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth_challenge_tokenizer.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_challenge_tokenizer.h#kjEvEnCJ9C%2By8r6dA7WBCh4pigdrfc4vNGN1cB9bnf0%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 810, 
+          "range": {
+            "start_line": 78, 
+            "end_line": 78, 
+            "start_column": 32, 
+            "end_column": 36
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_challenge_tokenizer.cc", 
+            "range": {
+              "start_line": 11, 
+              "end_line": 11, 
+              "start_column": 29, 
+              "end_column": 54
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_challenge_tokenizer.cc#%40308%3A334%40Jli9CaAd%2B8Ai%2Fddq4vrL%2BirawRrG0lCnuvJj8c%2FV8Ig%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth_challenge_tokenizer.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_challenge_tokenizer.h#%2Bmvtv6hhs7yL1PWcjFCN%2BL0GcaKwF9RvGTcD3KxoxP4%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 78, 
+            "end_line": 78, 
+            "start_column": 38, 
+            "end_column": 46
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 74, 
+              "end_line": 74, 
+              "start_column": 15, 
+              "end_column": 23
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402694%3A2703%40%2FZarsaZ0yht4g9p%2BVPvibKVgNDCj8UGk3%2BP1otnH1eU%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%2FZarsaZ0yht4g9p%2BVPvibKVgNDCj8UGk3%2BP1otnH1eU%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 78, 
+            "end_line": 78, 
+            "start_column": 48, 
+            "end_column": 52
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/string", 
+            "range": {
+              "start_line": 857, 
+              "end_line": 857, 
+              "start_column": 14, 
+              "end_column": 18
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/string#%4035384%3A35389%40PQxfXJGdd5dMtCZ%2Bi9uB6axfI6FWAVlFCsPzJ%2FdLQic%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fstring", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#o0a6Fpk%2B4%2FJHhDVS9Luof6DjtkGmn6nZbnJof5YPzHo%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 78, 
+            "end_line": 78, 
+            "start_column": 57, 
+            "end_column": 65
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 74, 
+              "end_line": 74, 
+              "start_column": 15, 
+              "end_column": 23
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402694%3A2703%40%2FZarsaZ0yht4g9p%2BVPvibKVgNDCj8UGk3%2BP1otnH1eU%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%2FZarsaZ0yht4g9p%2BVPvibKVgNDCj8UGk3%2BP1otnH1eU%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 78, 
+            "end_line": 78, 
+            "start_column": 67, 
+            "end_column": 69
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/string", 
+            "range": {
+              "start_line": 863, 
+              "end_line": 863, 
+              "start_column": 14, 
+              "end_column": 16
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/string#%4035612%3A35615%40cw1dgnfCjBCSLNO8%2FLEiRPoCgpu1cqwUEu%2FiFUOHCko%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fstring", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#tlQzUj%2BFvb%2FIyOXfnswdVfgCoxvy7iLYcUzWnOMuFAE%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 800, 
+          "range": {
+            "start_line": 79, 
+            "end_line": 79, 
+            "start_column": 16, 
+            "end_column": 35
+          }, 
+          "internal_link": {
+            "path": "src/base/strings/string_util.cc", 
+            "range": {
+              "start_line": 559, 
+              "end_line": 559, 
+              "start_column": 6, 
+              "end_column": 25
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/base/strings/string_util.cc#%4018420%3A18440%40Pb%2FZ%2BR6D6EMjCKgf%2BmGrp7KoCp8yaqvJjq5vjSu7s4A%3D%23chromium%23src%2Fbase%2Fstrings%2Fstring_util.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/base/strings/string_util.h#H6KfShajY6w%2FVewRQI1ANas2Omn6r5FP2gHvFM7WT8Q%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 79, 
+            "end_line": 79, 
+            "start_column": 37, 
+            "end_column": 41
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 78, 
+              "end_line": 78, 
+              "start_column": 32, 
+              "end_column": 36
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402914%3A2919%40c1GoIYj9ZQGQsfeQVJk%2BT13m0%2F4leX3yeH9T4hQH4wY%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#c1GoIYj9ZQGQsfeQVJk%2BT13m0%2F4leX3yeH9T4hQH4wY%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 800, 
+          "range": {
+            "start_line": 79, 
+            "end_line": 79, 
+            "start_column": 43, 
+            "end_column": 48
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_challenge_tokenizer.h", 
+            "range": {
+              "start_line": 37, 
+              "end_line": 37, 
+              "start_column": 15, 
+              "end_column": 20
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_challenge_tokenizer.h#%401331%3A1337%405NX6ASoe%2BxeAqjBjjpr0XVv144%2BmN%2FwJ2i1W2xEOXL8%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth_challenge_tokenizer.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_challenge_tokenizer.h#5NX6ASoe%2BxeAqjBjjpr0XVv144%2BmN%2FwJ2i1W2xEOXL8%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 80, 
+            "end_line": 80, 
+            "start_column": 37, 
+            "end_column": 55
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 71, 
+              "end_line": 71, 
+              "start_column": 15, 
+              "end_column": 33
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402541%3A2560%40g0cRNw6A%2Bt%2BbpDZsiAuE3%2FMH%2BzcAgfa0RVh5hYz9fU0%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#g0cRNw6A%2Bt%2BbpDZsiAuE3%2FMH%2BzcAgfa0RVh5hYz9fU0%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 80, 
+            "end_line": 80, 
+            "start_column": 57, 
+            "end_column": 61
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/string", 
+            "range": {
+              "start_line": 1135, 
+              "end_line": 1135, 
+              "start_column": 23, 
+              "end_column": 27
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/string#%4048116%3A48121%40S4jcjOwC9YWEwZlftHTCcbi3%2FG803nkBwL%2FasqjwEJs%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fstring", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#kj90CzdzFErmV5wk%2FPbo5hBbDW36R%2FNnpuwWYlVz9p0%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 82, 
+            "end_line": 82, 
+            "start_column": 5, 
+            "end_column": 24
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 75, 
+              "end_line": 75, 
+              "start_column": 33, 
+              "end_column": 52
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402737%3A2757%40SkFTdEWPwYHDZJU%2B6%2F16hrjHAunxi9z6FvIaksDOW9Q%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#SkFTdEWPwYHDZJU%2B6%2F16hrjHAunxi9z6FvIaksDOW9Q%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 82, 
+            "end_line": 82, 
+            "start_column": 28, 
+            "end_column": 34
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 60, 
+              "end_line": 60, 
+              "start_column": 22, 
+              "end_column": 28
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402116%3A2123%40Ok4LgjzuSDZDBkmjk%2FuyWT2yWuTJAX9bGoeZHVBYAY4%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#Ok4LgjzuSDZDBkmjk%2FuyWT2yWuTJAX9bGoeZHVBYAY4%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 800, 
+          "range": {
+            "start_line": 82, 
+            "end_line": 82, 
+            "start_column": 37, 
+            "end_column": 58
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_handler.h", 
+            "range": {
+              "start_line": 61, 
+              "end_line": 61, 
+              "start_column": 41, 
+              "end_column": 62
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler.h#%402551%3A2573%40zKvQ2f9n5fjV726D3EqYvb32gNLDsAjSmvrEgTR1tnY%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth_handler.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler.h#zKvQ2f9n5fjV726D3EqYvb32gNLDsAjSmvrEgTR1tnY%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 82, 
+            "end_line": 82, 
+            "start_column": 61, 
+            "end_column": 65
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 78, 
+              "end_line": 78, 
+              "start_column": 32, 
+              "end_column": 36
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402914%3A2919%40c1GoIYj9ZQGQsfeQVJk%2BT13m0%2F4leX3yeH9T4hQH4wY%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#c1GoIYj9ZQGQsfeQVJk%2BT13m0%2F4leX3yeH9T4hQH4wY%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 83, 
+            "end_line": 83, 
+            "start_column": 9, 
+            "end_column": 28
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 75, 
+              "end_line": 75, 
+              "start_column": 33, 
+              "end_column": 52
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402737%3A2757%40SkFTdEWPwYHDZJU%2B6%2F16hrjHAunxi9z6FvIaksDOW9Q%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#SkFTdEWPwYHDZJU%2B6%2F16hrjHAunxi9z6FvIaksDOW9Q%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 83, 
+            "end_line": 83, 
+            "start_column": 33, 
+            "end_column": 40
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 27, 
+              "end_line": 27, 
+              "start_column": 26, 
+              "end_column": 33
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40621%3A629%40HttpAuth%3Anet%23c%23hUTvau_Z32C%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#HttpAuth%3Anet%23c%23hUTvau_Z32C"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 500, 
+          "range": {
+            "start_line": 83, 
+            "end_line": 83, 
+            "start_column": 43, 
+            "end_column": 70
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 53, 
+              "end_line": 53, 
+              "start_column": 5, 
+              "end_column": 32
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%401650%3A1678%40z%2BvaKuoWNRlPlv8ZBtk%2F2KWczFfDYiDqR15Q0zBMhJI%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#z%2BvaKuoWNRlPlv8ZBtk%2F2KWczFfDYiDqR15Q0zBMhJI%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 84, 
+            "end_line": 84, 
+            "start_column": 8, 
+            "end_column": 21
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 64, 
+              "end_line": 64, 
+              "start_column": 18, 
+              "end_column": 31
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402256%3A2270%40dW4FIpXZfUwQqx6bJisQbr80WGjMR4j0gGOOHAOj6ME%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#dW4FIpXZfUwQqx6bJisQbr80WGjMR4j0gGOOHAOj6ME%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1600, 
+          "range": {
+            "start_line": 84, 
+            "end_line": 84, 
+            "start_column": 23, 
+            "end_column": 23
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/string", 
+            "range": {
+              "start_line": 2071, 
+              "end_line": 2071, 
+              "start_column": 44, 
+              "end_column": 52
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/string#%4081380%3A81389%40pt%2FTSRkIJFXEGu3lx1S%2F%2F%2FOq%2BoveHWJh5srZDt7pK18%3D%23chromium%23src%2Fbuildtools%2Fthird_party%2Flibc%2B%2B%2Ftrunk%2Finclude%2Fstring", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#Ees2l9dyXjleEy2nQtc%2Fk3N5TCXbahGWKgj%2FGqfPRdQ%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 84, 
+            "end_line": 84, 
+            "start_column": 25, 
+            "end_column": 33
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 74, 
+              "end_line": 74, 
+              "start_column": 15, 
+              "end_column": 23
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402694%3A2703%40%2FZarsaZ0yht4g9p%2BVPvibKVgNDCj8UGk3%2BP1otnH1eU%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%2FZarsaZ0yht4g9p%2BVPvibKVgNDCj8UGk3%2BP1otnH1eU%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 85, 
+            "end_line": 85, 
+            "start_column": 14, 
+            "end_column": 33
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 75, 
+              "end_line": 75, 
+              "start_column": 33, 
+              "end_column": 52
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402737%3A2757%40SkFTdEWPwYHDZJU%2B6%2F16hrjHAunxi9z6FvIaksDOW9Q%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#SkFTdEWPwYHDZJU%2B6%2F16hrjHAunxi9z6FvIaksDOW9Q%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 89, 
+            "end_line": 89, 
+            "start_column": 10, 
+            "end_column": 17
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 27, 
+              "end_line": 27, 
+              "start_column": 26, 
+              "end_column": 33
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40621%3A629%40HttpAuth%3Anet%23c%23hUTvau_Z32C%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#HttpAuth%3Anet%23c%23hUTvau_Z32C"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 500, 
+          "range": {
+            "start_line": 89, 
+            "end_line": 89, 
+            "start_column": 20, 
+            "end_column": 46
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 47, 
+              "end_line": 47, 
+              "start_column": 5, 
+              "end_column": 31
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%401356%3A1383%40%2Bzs8xzJ1yfOYD7Mv08TfZHC2vceSbgzdy2f6x6MPRIc%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%2Bzs8xzJ1yfOYD7Mv08TfZHC2vceSbgzdy2f6x6MPRIc%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1500, 
+          "range": {
+            "start_line": 93, 
+            "end_line": 93, 
+            "start_column": 6, 
+            "end_column": 11
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/iosfwd", 
+            "range": {
+              "start_line": 194, 
+              "end_line": 194, 
+              "start_column": 65, 
+              "end_column": 70
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/iosfwd#%407594%3A7600%40Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 93, 
+            "end_line": 93, 
+            "start_column": 13, 
+            "end_column": 20
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 27, 
+              "end_line": 27, 
+              "start_column": 26, 
+              "end_column": 33
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40621%3A629%40HttpAuth%3Anet%23c%23hUTvau_Z32C%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#HttpAuth%3Anet%23c%23hUTvau_Z32C"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1410, 
+          "range": {
+            "start_line": 93, 
+            "end_line": 93, 
+            "start_column": 46, 
+            "end_column": 51
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 31, 
+              "end_line": 31, 
+              "start_column": 8, 
+              "end_column": 13
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40772%3A778%40Target%3AHttpAuth%3Anet%23n%23hMl2%24pd%24IrA%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#Target%3AHttpAuth%3Anet%23n%23hMl2%24pd%24IrA"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 94, 
+            "end_line": 94, 
+            "start_column": 11, 
+            "end_column": 16
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 93, 
+              "end_line": 93, 
+              "start_column": 53, 
+              "end_column": 58
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%403478%3A3484%40Pl3ZiR6%2Fosq31U0DIORsv0dh7KAVZYoI8D1iTCUv3n8%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#Pl3ZiR6%2Fosq31U0DIORsv0dh7KAVZYoI8D1iTCUv3n8%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 500, 
+          "range": {
+            "start_line": 95, 
+            "end_line": 95, 
+            "start_column": 10, 
+            "end_column": 19
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 35, 
+              "end_line": 35, 
+              "start_column": 5, 
+              "end_column": 14
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40919%3A929%40bIa8P94vUg076%2FA9U%2Bb1OXn7zDmWQ%2B8QVxzIPb9MjRE%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#bIa8P94vUg076%2FA9U%2Bb1OXn7zDmWQ%2B8QVxzIPb9MjRE%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 500, 
+          "range": {
+            "start_line": 97, 
+            "end_line": 97, 
+            "start_column": 10, 
+            "end_column": 20
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 36, 
+              "end_line": 36, 
+              "start_column": 5, 
+              "end_column": 15
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40939%3A950%40UhtX0XiMD4%2FbyG1JQ09iYzby1xJtXO6DUWpQBbDPhxc%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#UhtX0XiMD4%2FbyG1JQ09iYzby1xJtXO6DUWpQBbDPhxc%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1000, 
+          "range": {
+            "start_line": 100, 
+            "end_line": 100, 
+            "start_column": 7, 
+            "end_column": 16
+          }, 
+          "internal_link": {
+            "path": "src/base/logging.h", 
+            "range": {
+              "start_line": 947, 
+              "end_line": 947, 
+              "start_column": 9, 
+              "end_column": 18
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/base/logging.h#%4040221%3A40231%40NOTREACHED%23m%4040221%23chromium%23src%2Fbase%2Flogging.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/base/logging.h#NOTREACHED%23m%4040221"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1500, 
+          "range": {
+            "start_line": 101, 
+            "end_line": 101, 
+            "start_column": 19, 
+            "end_column": 24
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/iosfwd", 
+            "range": {
+              "start_line": 194, 
+              "end_line": 194, 
+              "start_column": 65, 
+              "end_column": 70
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/iosfwd#%407594%3A7600%40Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1500, 
+          "range": {
+            "start_line": 106, 
+            "end_line": 106, 
+            "start_column": 6, 
+            "end_column": 11
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/iosfwd", 
+            "range": {
+              "start_line": 194, 
+              "end_line": 194, 
+              "start_column": 65, 
+              "end_column": 70
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/iosfwd#%407594%3A7600%40Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 106, 
+            "end_line": 106, 
+            "start_column": 13, 
+            "end_column": 20
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 27, 
+              "end_line": 27, 
+              "start_column": 26, 
+              "end_column": 33
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40621%3A629%40HttpAuth%3Anet%23c%23hUTvau_Z32C%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#HttpAuth%3Anet%23c%23hUTvau_Z32C"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1410, 
+          "range": {
+            "start_line": 106, 
+            "end_line": 106, 
+            "start_column": 50, 
+            "end_column": 55
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 31, 
+              "end_line": 31, 
+              "start_column": 8, 
+              "end_column": 13
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40772%3A778%40Target%3AHttpAuth%3Anet%23n%23hMl2%24pd%24IrA%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#Target%3AHttpAuth%3Anet%23n%23hMl2%24pd%24IrA"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 107, 
+            "end_line": 107, 
+            "start_column": 11, 
+            "end_column": 16
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 106, 
+              "end_line": 106, 
+              "start_column": 57, 
+              "end_column": 62
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%403753%3A3759%40gD7dPW6MXxmgXqJWHZq4afyl6zY2TaOiFoc6c3Ax8Uw%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#gD7dPW6MXxmgXqJWHZq4afyl6zY2TaOiFoc6c3Ax8Uw%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 500, 
+          "range": {
+            "start_line": 108, 
+            "end_line": 108, 
+            "start_column": 10, 
+            "end_column": 19
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 35, 
+              "end_line": 35, 
+              "start_column": 5, 
+              "end_column": 14
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40919%3A929%40bIa8P94vUg076%2FA9U%2Bb1OXn7zDmWQ%2B8QVxzIPb9MjRE%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#bIa8P94vUg076%2FA9U%2Bb1OXn7zDmWQ%2B8QVxzIPb9MjRE%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 109, 
+            "end_line": 109, 
+            "start_column": 14, 
+            "end_column": 31
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_request_headers.h", 
+            "range": {
+              "start_line": 29, 
+              "end_line": 29, 
+              "start_column": 18, 
+              "end_column": 35
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_request_headers.h#%40723%3A741%40HttpRequestHeaders%3Anet%23c%23LUgSB%242CR7%23chromium%23src%2Fnet%2Fhttp%2Fhttp_request_headers.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_request_headers.h#HttpRequestHeaders%3Anet%23c%23LUgSB%242CR7"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 109, 
+            "end_line": 109, 
+            "start_column": 34, 
+            "end_column": 52
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_request_headers.cc", 
+            "range": {
+              "start_line": 39, 
+              "end_line": 39, 
+              "start_column": 32, 
+              "end_column": 50
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_request_headers.cc#%401711%3A1730%40FnphyuQR6ZtNy1xPEd3ielAIPM6MVkktoAIxMvX3l%2B0%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_request_headers.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_request_headers.h#qyQc54TyyONFJl4XgL0JFFBloyCgJXY9HD%2BetRe%2FDI0%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 500, 
+          "range": {
+            "start_line": 110, 
+            "end_line": 110, 
+            "start_column": 10, 
+            "end_column": 20
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 36, 
+              "end_line": 36, 
+              "start_column": 5, 
+              "end_column": 15
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40939%3A950%40UhtX0XiMD4%2FbyG1JQ09iYzby1xJtXO6DUWpQBbDPhxc%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#UhtX0XiMD4%2FbyG1JQ09iYzby1xJtXO6DUWpQBbDPhxc%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 111, 
+            "end_line": 111, 
+            "start_column": 14, 
+            "end_column": 31
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_request_headers.h", 
+            "range": {
+              "start_line": 29, 
+              "end_line": 29, 
+              "start_column": 18, 
+              "end_column": 35
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_request_headers.h#%40723%3A741%40HttpRequestHeaders%3Anet%23c%23LUgSB%242CR7%23chromium%23src%2Fnet%2Fhttp%2Fhttp_request_headers.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_request_headers.h#HttpRequestHeaders%3Anet%23c%23LUgSB%242CR7"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 111, 
+            "end_line": 111, 
+            "start_column": 34, 
+            "end_column": 47
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_request_headers.cc", 
+            "range": {
+              "start_line": 25, 
+              "end_line": 25, 
+              "start_column": 32, 
+              "end_column": 45
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_request_headers.cc#%40850%3A864%40B6%2FD5Z2ThUlWSCwUBdhfMttH2xhuCE4rysIcIv4uinw%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_request_headers.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_request_headers.h#NVTxKlsQn15slaMuW7L%2FFX5LLTm0AB9F3KqscCqnZ3w%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1000, 
+          "range": {
+            "start_line": 113, 
+            "end_line": 113, 
+            "start_column": 7, 
+            "end_column": 16
+          }, 
+          "internal_link": {
+            "path": "src/base/logging.h", 
+            "range": {
+              "start_line": 947, 
+              "end_line": 947, 
+              "start_column": 9, 
+              "end_column": 18
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/base/logging.h#%4040221%3A40231%40NOTREACHED%23m%4040221%23chromium%23src%2Fbase%2Flogging.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/base/logging.h#NOTREACHED%23m%4040221"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1500, 
+          "range": {
+            "start_line": 114, 
+            "end_line": 114, 
+            "start_column": 19, 
+            "end_column": 24
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/iosfwd", 
+            "range": {
+              "start_line": 194, 
+              "end_line": 194, 
+              "start_column": 65, 
+              "end_column": 70
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/iosfwd#%407594%3A7600%40Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1500, 
+          "range": {
+            "start_line": 119, 
+            "end_line": 119, 
+            "start_column": 6, 
+            "end_column": 11
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/iosfwd", 
+            "range": {
+              "start_line": 194, 
+              "end_line": 194, 
+              "start_column": 65, 
+              "end_column": 70
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/iosfwd#%407594%3A7600%40Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 119, 
+            "end_line": 119, 
+            "start_column": 13, 
+            "end_column": 20
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 27, 
+              "end_line": 27, 
+              "start_column": 26, 
+              "end_column": 33
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40621%3A629%40HttpAuth%3Anet%23c%23hUTvau_Z32C%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#HttpAuth%3Anet%23c%23hUTvau_Z32C"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1410, 
+          "range": {
+            "start_line": 119, 
+            "end_line": 119, 
+            "start_column": 43, 
+            "end_column": 48
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 31, 
+              "end_line": 31, 
+              "start_column": 8, 
+              "end_column": 13
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40772%3A778%40Target%3AHttpAuth%3Anet%23n%23hMl2%24pd%24IrA%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#Target%3AHttpAuth%3Anet%23n%23hMl2%24pd%24IrA"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 120, 
+            "end_line": 120, 
+            "start_column": 11, 
+            "end_column": 16
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 119, 
+              "end_line": 119, 
+              "start_column": 50, 
+              "end_column": 55
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%404056%3A4062%40to%2FO9PF7%2FkVGKVTCXBJGlXA2bNxm1bDoQozYo%2BzWFmk%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#to%2FO9PF7%2FkVGKVTCXBJGlXA2bNxm1bDoQozYo%2BzWFmk%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 500, 
+          "range": {
+            "start_line": 121, 
+            "end_line": 121, 
+            "start_column": 10, 
+            "end_column": 19
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 35, 
+              "end_line": 35, 
+              "start_column": 5, 
+              "end_column": 14
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40919%3A929%40bIa8P94vUg076%2FA9U%2Bb1OXn7zDmWQ%2B8QVxzIPb9MjRE%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#bIa8P94vUg076%2FA9U%2Bb1OXn7zDmWQ%2B8QVxzIPb9MjRE%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 500, 
+          "range": {
+            "start_line": 123, 
+            "end_line": 123, 
+            "start_column": 10, 
+            "end_column": 20
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 36, 
+              "end_line": 36, 
+              "start_column": 5, 
+              "end_column": 15
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40939%3A950%40UhtX0XiMD4%2FbyG1JQ09iYzby1xJtXO6DUWpQBbDPhxc%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#UhtX0XiMD4%2FbyG1JQ09iYzby1xJtXO6DUWpQBbDPhxc%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1000, 
+          "range": {
+            "start_line": 126, 
+            "end_line": 126, 
+            "start_column": 7, 
+            "end_column": 16
+          }, 
+          "internal_link": {
+            "path": "src/base/logging.h", 
+            "range": {
+              "start_line": 947, 
+              "end_line": 947, 
+              "start_column": 9, 
+              "end_column": 18
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/base/logging.h#%4040221%3A40231%40NOTREACHED%23m%4040221%23chromium%23src%2Fbase%2Flogging.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/base/logging.h#NOTREACHED%23m%4040221"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1500, 
+          "range": {
+            "start_line": 127, 
+            "end_line": 127, 
+            "start_column": 19, 
+            "end_column": 24
+          }, 
+          "internal_link": {
+            "path": "src/buildtools/third_party/libc++/trunk/include/iosfwd", 
+            "range": {
+              "start_line": 194, 
+              "end_line": 194, 
+              "start_column": 65, 
+              "end_column": 70
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/buildtools/third_party/libc%2B%2B/trunk/include/iosfwd#%407594%3A7600%40Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D", 
+            "package_name": "chromium", 
+            "signature": "kythe:?lang=c%2B%2B#Z0QpSyHn5mg8B9ROi%2FxIOkJy1h1gAjkQowhuNSYfHkk%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1310, 
+          "range": {
+            "start_line": 132, 
+            "end_line": 132, 
+            "start_column": 13, 
+            "end_column": 20
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 27, 
+              "end_line": 27, 
+              "start_column": 26, 
+              "end_column": 33
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%40621%3A629%40HttpAuth%3Anet%23c%23hUTvau_Z32C%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#HttpAuth%3Anet%23c%23hUTvau_Z32C"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1410, 
+          "range": {
+            "start_line": 132, 
+            "end_line": 132, 
+            "start_column": 38, 
+            "end_column": 43
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 91, 
+              "end_line": 91, 
+              "start_column": 8, 
+              "end_column": 13
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%403144%3A3150%40Scheme%3AHttpAuth%3Anet%23n%23pQDbnWB0DcW%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#Scheme%3AHttpAuth%3Anet%23n%23pQDbnWB0DcW"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 134, 
+            "end_line": 134, 
+            "start_column": 7, 
+            "end_column": 22
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_scheme.cc", 
+            "range": {
+              "start_line": 8, 
+              "end_line": 8, 
+              "start_column": 12, 
+              "end_column": 27
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_scheme.cc#%40233%3A249%40hIMebTSclxZBn8zpVRecgxUX8hB4%2BB%2Bc0ZyoEVV4ZlM%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth_scheme.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_scheme.h#06Vqih%2FO7tP%2FJ%2B%2FUMrgkt0XWgwtf4lbce75ikslksjE%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 134, 
+            "end_line": 134, 
+            "start_column": 29, 
+            "end_column": 45
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_scheme.cc", 
+            "range": {
+              "start_line": 9, 
+              "end_line": 9, 
+              "start_column": 12, 
+              "end_column": 28
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_scheme.cc#%40274%3A291%40%2BxihPEFJ3EMLxThfcCa3Sn7Et80CfGK0oaogLg3F0l4%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth_scheme.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_scheme.h#kwFJpuxlU0nP2fpdRPdkRfoL%2B8XsH50d4mc%2BNE%2FpFZk%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 134, 
+            "end_line": 134, 
+            "start_column": 51, 
+            "end_column": 65
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_scheme.cc", 
+            "range": {
+              "start_line": 10, 
+              "end_line": 10, 
+              "start_column": 12, 
+              "end_column": 26
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_scheme.cc#%40317%3A332%40mIWDXWqyGwbxy0oxjQPeTnY4ZSbwU%2FR5EAZmpx1muVM%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth_scheme.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_scheme.h#rK1I40zJkpp%2FXGiCzpbKNf9Q7d4K00rNd1zvL2i%2F234%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 135, 
+            "end_line": 135, 
+            "start_column": 7, 
+            "end_column": 26
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_scheme.cc", 
+            "range": {
+              "start_line": 11, 
+              "end_line": 11, 
+              "start_column": 12, 
+              "end_column": 31
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_scheme.cc#%40356%3A376%40hmpY%2Bw561NjJgV4s0FmPFpEdm%2Bc6RmudhwPKLDg1Ets%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth_scheme.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_scheme.h#%2B%2FdekTPVDDRsdj4g4SbMecUeEInPAfg4%2FID3lR05MDE%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 135, 
+            "end_line": 135, 
+            "start_column": 29, 
+            "end_column": 48
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_scheme.cc", 
+            "range": {
+              "start_line": 12, 
+              "end_line": 12, 
+              "start_column": 12, 
+              "end_column": 31
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_scheme.cc#%40405%3A425%40pd8JGvas8Ba9zqZ5expKy2aQs0a33EX2xe%2FzqSOTp64%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth_scheme.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_scheme.h#S9uMFaxuJ33WyHJvmQ%2FP9QRBCyR%2F2WHMBqn%2F18X6M0c%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 135, 
+            "end_line": 135, 
+            "start_column": 51, 
+            "end_column": 65
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth_scheme.cc", 
+            "range": {
+              "start_line": 13, 
+              "end_line": 13, 
+              "start_column": 12, 
+              "end_column": 26
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_scheme.cc#%40454%3A469%40X8RXu8zBG63ldtX%2Fp2fqCdBAGhtqba9mtOI3016DJvA%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth_scheme.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_scheme.h#nACogiJpv7eMWNWrO2J1biSRqEKSfhwKnIc6z5lVY3I%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1000, 
+          "range": {
+            "start_line": 136, 
+            "end_line": 136, 
+            "start_column": 17, 
+            "end_column": 25
+          }, 
+          "internal_link": {
+            "path": "src/base/macros.h", 
+            "range": {
+              "start_line": 54, 
+              "end_line": 54, 
+              "start_column": 9, 
+              "end_column": 17
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/base/macros.h#%402170%3A2179%40arraysize%23m%402170%23chromium%23src%2Fbase%2Fmacros.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/base/macros.h#arraysize%23m%402170"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 136, 
+            "end_line": 136, 
+            "start_column": 27, 
+            "end_column": 38
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 133, 
+              "end_line": 133, 
+              "start_column": 28, 
+              "end_column": 39
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%404333%3A4345%40tbrzJ0avilgQmYSR4Ha11ZsJ%2FRvqSPNIi2RigdVIRUQ%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#tbrzJ0avilgQmYSR4Ha11ZsJ%2FRvqSPNIi2RigdVIRUQ%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 500, 
+          "range": {
+            "start_line": 136, 
+            "end_line": 136, 
+            "start_column": 44, 
+            "end_column": 58
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 98, 
+              "end_line": 98, 
+              "start_column": 5, 
+              "end_column": 19
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%403306%3A3321%408yaAVBgRqcZU%2BMixXog9rsx2sfWQjztjcZUSJJLDs3I%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#8yaAVBgRqcZU%2BMixXog9rsx2sfWQjztjcZUSJJLDs3I%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 138, 
+            "end_line": 138, 
+            "start_column": 7, 
+            "end_column": 12
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 132, 
+              "end_line": 132, 
+              "start_column": 45, 
+              "end_column": 50
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%404296%3A4302%40auKzBxRhjuE6E49w7noqo9vLpjspbltARkox%2BOhFiCY%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#auKzBxRhjuE6E49w7noqo9vLpjspbltARkox%2BOhFiCY%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 500, 
+          "range": {
+            "start_line": 138, 
+            "end_line": 138, 
+            "start_column": 16, 
+            "end_column": 32
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 92, 
+              "end_line": 92, 
+              "start_column": 5, 
+              "end_column": 21
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%403157%3A3174%40vqAOrhpDEVRUYJIUD3fRhIBMDseO0kWra1bzlhKwiVk%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#vqAOrhpDEVRUYJIUD3fRhIBMDseO0kWra1bzlhKwiVk%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 138, 
+            "end_line": 138, 
+            "start_column": 37, 
+            "end_column": 42
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 132, 
+              "end_line": 132, 
+              "start_column": 45, 
+              "end_column": 50
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%404296%3A4302%40auKzBxRhjuE6E49w7noqo9vLpjspbltARkox%2BOhFiCY%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#auKzBxRhjuE6E49w7noqo9vLpjspbltARkox%2BOhFiCY%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 500, 
+          "range": {
+            "start_line": 138, 
+            "end_line": 138, 
+            "start_column": 47, 
+            "end_column": 61
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.h", 
+            "range": {
+              "start_line": 98, 
+              "end_line": 98, 
+              "start_column": 5, 
+              "end_column": 19
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%403306%3A3321%408yaAVBgRqcZU%2BMixXog9rsx2sfWQjztjcZUSJJLDs3I%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#8yaAVBgRqcZU%2BMixXog9rsx2sfWQjztjcZUSJJLDs3I%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1000, 
+          "range": {
+            "start_line": 139, 
+            "end_line": 139, 
+            "start_column": 5, 
+            "end_column": 14
+          }, 
+          "internal_link": {
+            "path": "src/base/logging.h", 
+            "range": {
+              "start_line": 947, 
+              "end_line": 947, 
+              "start_column": 9, 
+              "end_column": 18
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/base/logging.h#%4040221%3A40231%40NOTREACHED%23m%4040221%23chromium%23src%2Fbase%2Flogging.h", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/base/logging.h#NOTREACHED%23m%4040221"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 142, 
+            "end_line": 142, 
+            "start_column": 10, 
+            "end_column": 21
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 133, 
+              "end_line": 133, 
+              "start_column": 28, 
+              "end_column": 39
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%404333%3A4345%40tbrzJ0avilgQmYSR4Ha11ZsJ%2FRvqSPNIi2RigdVIRUQ%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#tbrzJ0avilgQmYSR4Ha11ZsJ%2FRvqSPNIi2RigdVIRUQ%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "kythe_xref_kind": 1900, 
+          "range": {
+            "start_line": 142, 
+            "end_line": 142, 
+            "start_column": 23, 
+            "end_column": 28
+          }, 
+          "internal_link": {
+            "path": "src/net/http/http_auth.cc", 
+            "range": {
+              "start_line": 132, 
+              "end_line": 132, 
+              "start_column": 45, 
+              "end_column": 50
+            }, 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%404296%3A4302%40auKzBxRhjuE6E49w7noqo9vLpjspbltARkox%2BOhFiCY%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "package_name": "chromium", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#auKzBxRhjuE6E49w7noqo9vLpjspbltARkox%2BOhFiCY%3D"
+          }, 
+          "type": {
+            "id": 1
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 22, 
+            "end_line": 22, 
+            "start_column": 21, 
+            "end_column": 28
+          }, 
+          "kythe_xref_kind": 810, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#zQrDc1pyLaeTXXAFH7SO9DXAcllRRCP7FvR2%2FcxjgJA%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 25, 
+            "end_line": 25, 
+            "start_column": 16, 
+            "end_column": 34
+          }, 
+          "kythe_xref_kind": 800, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%40755%3A774%40Nrxbg2wUMb7TnDHlFpxZyOQVIkRE3PT9Fb4TKk23Pqg%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#Nrxbg2wUMb7TnDHlFpxZyOQVIkRE3PT9Fb4TKk23Pqg%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 26, 
+            "end_line": 26, 
+            "start_column": 29, 
+            "end_column": 53
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%40804%3A829%40%2BPr0ofpYBwMJdsuwPQh2co4YkaKAf%2Fyu9Wo7bS3zNl4%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%2BPr0ofpYBwMJdsuwPQh2co4YkaKAf%2Fyu9Wo7bS3zNl4%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 27, 
+            "end_line": 27, 
+            "start_column": 32, 
+            "end_column": 47
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%40862%3A878%40MCiey3DmeeSlo4BrqkK9ptuW2Zpcj%2BsQqLjEX%2BnznkE%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#MCiey3DmeeSlo4BrqkK9ptuW2Zpcj%2BsQqLjEX%2BnznkE%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 28, 
+            "end_line": 28, 
+            "start_column": 20, 
+            "end_column": 27
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%40899%3A907%40nrtZJ6eT%2BvMjiyaqLAfXyZn04AXm1j%2F2ElhPGm0g3Zg%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#nrtZJ6eT%2BvMjiyaqLAfXyZn04AXm1j%2F2ElhPGm0g3Zg%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 29, 
+            "end_line": 29, 
+            "start_column": 12, 
+            "end_column": 17
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%40920%3A926%40wWGN9AvhGQmf3iv%2FpLgTpciDps9E9Wx0TjK6cuBfYgk%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#wWGN9AvhGQmf3iv%2FpLgTpciDps9E9Wx0TjK6cuBfYgk%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 30, 
+            "end_line": 30, 
+            "start_column": 17, 
+            "end_column": 22
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%40944%3A950%40vOzjdpAmZc2RvaAvS3FzvN59FZ%2BE2%2B1FHQXTCkZBPLk%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#vOzjdpAmZc2RvaAvS3FzvN59FZ%2BE2%2B1FHQXTCkZBPLk%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 31, 
+            "end_line": 31, 
+            "start_column": 29, 
+            "end_column": 44
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%40980%3A996%40rRrbLmhqydZdc2uyX%2FKCvn%2F7ZRu%2FgPeicu6Wq9ZWRSs%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#rRrbLmhqydZdc2uyX%2FKCvn%2F7ZRu%2FgPeicu6Wq9ZWRSs%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 32, 
+            "end_line": 32, 
+            "start_column": 29, 
+            "end_column": 35
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401026%3A1033%40q7wXRjuHWNLRrTf06QFcNg6ghbJvypaBsGHf74AC5N8%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#q7wXRjuHWNLRrTf06QFcNg6ghbJvypaBsGHf74AC5N8%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 33, 
+            "end_line": 33, 
+            "start_column": 39, 
+            "end_column": 45
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401073%3A1080%40AdDpcSmKLbTyOOqmkMLUpSJqw2avljg%2F85ZcuQ5RB1Q%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#AdDpcSmKLbTyOOqmkMLUpSJqw2avljg%2F85ZcuQ5RB1Q%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 38, 
+            "end_line": 38, 
+            "start_column": 36, 
+            "end_column": 39
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401271%3A1275%40Y1tkEBlo2BCaNFu%2BW0GyMZ4%2BYXInBcyF6hrR9CfeWj0%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#Y1tkEBlo2BCaNFu%2BW0GyMZ4%2BYXInBcyF6hrR9CfeWj0%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 39, 
+            "end_line": 39, 
+            "start_column": 21, 
+            "end_column": 31
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401297%3A1308%40JGSyS9RLBbogLyKz1uB84cVIJnoETLnQVutdmXURFuY%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#JGSyS9RLBbogLyKz1uB84cVIJnoETLnQVutdmXURFuY%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 40, 
+            "end_line": 40, 
+            "start_column": 15, 
+            "end_column": 27
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401357%3A1370%40jJnDsLO60yQThw5YWPRzAc0pTfFV2cWIJedO3CKUI2M%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#jJnDsLO60yQThw5YWPRzAc0pTfFV2cWIJedO3CKUI2M%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 41, 
+            "end_line": 41, 
+            "start_column": 10, 
+            "end_column": 13
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401381%3A1385%40%2BuD8Z59fY15SoBAM6qFZ0Mu4NFAsjO76Q9RetLyQITY%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%2BuD8Z59fY15SoBAM6qFZ0Mu4NFAsjO76Q9RetLyQITY%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 43, 
+            "end_line": 43, 
+            "start_column": 38, 
+            "end_column": 40
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401509%3A1512%409YGI9TmZyTlDu%2B20zsvrUzcNZoTZZ%2FSEjbCZACNgzkQ%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#9YGI9TmZyTlDu%2B20zsvrUzcNZoTZZ%2FSEjbCZACNgzkQ%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 44, 
+            "end_line": 44, 
+            "start_column": 9, 
+            "end_column": 10
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%401522%3A1524%40ckCsolLifkGdY6OimJyejxWQQ4PX464tylv5M7%2FVxwk%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#ckCsolLifkGdY6OimJyejxWQQ4PX464tylv5M7%2FVxwk%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 59, 
+            "end_line": 59, 
+            "start_column": 41, 
+            "end_column": 63
+          }, 
+          "kythe_xref_kind": 800, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402070%3A2093%40d5g4r5SZtTnWp4jk8aPgyc2HqOyOQwViw6Ct0PQ6tqY%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#d5g4r5SZtTnWp4jk8aPgyc2HqOyOQwViw6Ct0PQ6tqY%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 60, 
+            "end_line": 60, 
+            "start_column": 22, 
+            "end_column": 28
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402116%3A2123%40Ok4LgjzuSDZDBkmjk%2FuyWT2yWuTJAX9bGoeZHVBYAY4%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#Ok4LgjzuSDZDBkmjk%2FuyWT2yWuTJAX9bGoeZHVBYAY4%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 61, 
+            "end_line": 61, 
+            "start_column": 32, 
+            "end_column": 47
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402156%3A2172%40b56hUwpTTye5qHFZRHyIkaDNpb2Hknzksp6pdky8VqM%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#b56hUwpTTye5qHFZRHyIkaDNpb2Hknzksp6pdky8VqM%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 62, 
+            "end_line": 62, 
+            "start_column": 12, 
+            "end_column": 17
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402185%3A2191%40zQWSOtka6iEjrC%2F6YiKlFXwlxonuHGKyT8D8RK5v2hw%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#zQWSOtka6iEjrC%2F6YiKlFXwlxonuHGKyT8D8RK5v2hw%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 63, 
+            "end_line": 63, 
+            "start_column": 29, 
+            "end_column": 44
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402221%3A2237%40ombJf5xJ%2Fn3IpCOjANPsrnUsf5VLpZriLEuIh3kQf74%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#ombJf5xJ%2Fn3IpCOjANPsrnUsf5VLpZriLEuIh3kQf74%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 64, 
+            "end_line": 64, 
+            "start_column": 18, 
+            "end_column": 31
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402256%3A2270%40dW4FIpXZfUwQqx6bJisQbr80WGjMR4j0gGOOHAOj6ME%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#dW4FIpXZfUwQqx6bJisQbr80WGjMR4j0gGOOHAOj6ME%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 68, 
+            "end_line": 68, 
+            "start_column": 20, 
+            "end_column": 33
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402365%3A2379%40Aqah1wrC%2FCkVahDI2ljrB5B7fqlpLH3Id8r6D4sjEYs%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#Aqah1wrC%2FCkVahDI2ljrB5B7fqlpLH3Id8r6D4sjEYs%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 71, 
+            "end_line": 71, 
+            "start_column": 15, 
+            "end_column": 33
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402541%3A2560%40g0cRNw6A%2Bt%2BbpDZsiAuE3%2FMH%2BzcAgfa0RVh5hYz9fU0%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#g0cRNw6A%2Bt%2BbpDZsiAuE3%2FMH%2BzcAgfa0RVh5hYz9fU0%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 72, 
+            "end_line": 72, 
+            "start_column": 21, 
+            "end_column": 31
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402615%3A2626%40gpiJ92vk3ysmqLRN5LF62wME9MjLdQIxaLAQfSbVMaE%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#gpiJ92vk3ysmqLRN5LF62wME9MjLdQIxaLAQfSbVMaE%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 73, 
+            "end_line": 73, 
+            "start_column": 10, 
+            "end_column": 13
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402670%3A2674%40dwWzcX%2Fw1baerdEqIUuAndlRLmhvuFBl5M8cx57qhkE%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#dwWzcX%2Fw1baerdEqIUuAndlRLmhvuFBl5M8cx57qhkE%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 74, 
+            "end_line": 74, 
+            "start_column": 15, 
+            "end_column": 23
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402694%3A2703%40%2FZarsaZ0yht4g9p%2BVPvibKVgNDCj8UGk3%2BP1otnH1eU%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%2FZarsaZ0yht4g9p%2BVPvibKVgNDCj8UGk3%2BP1otnH1eU%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 75, 
+            "end_line": 75, 
+            "start_column": 33, 
+            "end_column": 52
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402737%3A2757%40SkFTdEWPwYHDZJU%2B6%2F16hrjHAunxi9z6FvIaksDOW9Q%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#SkFTdEWPwYHDZJU%2B6%2F16hrjHAunxi9z6FvIaksDOW9Q%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 78, 
+            "end_line": 78, 
+            "start_column": 32, 
+            "end_column": 36
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%402914%3A2919%40c1GoIYj9ZQGQsfeQVJk%2BT13m0%2F4leX3yeH9T4hQH4wY%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#c1GoIYj9ZQGQsfeQVJk%2BT13m0%2F4leX3yeH9T4hQH4wY%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 93, 
+            "end_line": 93, 
+            "start_column": 23, 
+            "end_column": 44
+          }, 
+          "kythe_xref_kind": 800, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%403448%3A3470%40DRyCpVzYc1Hj4MuTTgDXCoXjPgyNLkegGhVqJJte51I%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#DRyCpVzYc1Hj4MuTTgDXCoXjPgyNLkegGhVqJJte51I%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 93, 
+            "end_line": 93, 
+            "start_column": 53, 
+            "end_column": 58
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%403478%3A3484%40Pl3ZiR6%2Fosq31U0DIORsv0dh7KAVZYoI8D1iTCUv3n8%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#Pl3ZiR6%2Fosq31U0DIORsv0dh7KAVZYoI8D1iTCUv3n8%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 106, 
+            "end_line": 106, 
+            "start_column": 23, 
+            "end_column": 48
+          }, 
+          "kythe_xref_kind": 800, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%403719%3A3745%402s8TDM9BXINQTtNqVwC62QrFO1n7aqQWjOYuBZ0Kx3c%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#2s8TDM9BXINQTtNqVwC62QrFO1n7aqQWjOYuBZ0Kx3c%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 106, 
+            "end_line": 106, 
+            "start_column": 57, 
+            "end_column": 62
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%403753%3A3759%40gD7dPW6MXxmgXqJWHZq4afyl6zY2TaOiFoc6c3Ax8Uw%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#gD7dPW6MXxmgXqJWHZq4afyl6zY2TaOiFoc6c3Ax8Uw%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 119, 
+            "end_line": 119, 
+            "start_column": 23, 
+            "end_column": 41
+          }, 
+          "kythe_xref_kind": 800, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%404029%3A4048%40RYLRBkQmDpB5FUsM7fx5VoB2cqLXRVJNc4F6OiOVQpQ%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#RYLRBkQmDpB5FUsM7fx5VoB2cqLXRVJNc4F6OiOVQpQ%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 119, 
+            "end_line": 119, 
+            "start_column": 50, 
+            "end_column": 55
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%404056%3A4062%40to%2FO9PF7%2FkVGKVTCXBJGlXA2bNxm1bDoQozYo%2BzWFmk%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#to%2FO9PF7%2FkVGKVTCXBJGlXA2bNxm1bDoQozYo%2BzWFmk%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 132, 
+            "end_line": 132, 
+            "start_column": 23, 
+            "end_column": 36
+          }, 
+          "kythe_xref_kind": 800, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%404274%3A4288%40%2Fb%2BRIOVl8o6nlI1otAdGcLGZTqbEJ5i6AOQiav6%2BhI0%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%2Fb%2BRIOVl8o6nlI1otAdGcLGZTqbEJ5i6AOQiav6%2BhI0%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 132, 
+            "end_line": 132, 
+            "start_column": 45, 
+            "end_column": 50
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%404296%3A4302%40auKzBxRhjuE6E49w7noqo9vLpjspbltARkox%2BOhFiCY%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#auKzBxRhjuE6E49w7noqo9vLpjspbltARkox%2BOhFiCY%3D"
+          }
+        }, 
+        {
+          "range": {
+            "start_line": 133, 
+            "end_line": 133, 
+            "start_column": 28, 
+            "end_column": 39
+          }, 
+          "kythe_xref_kind": 1900, 
+          "type": {
+            "id": 4
+          }, 
+          "xref_signature": {
+            "signature_hash": "", 
+            "highlight_signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%404333%3A4345%40tbrzJ0avilgQmYSR4Ha11ZsJ%2FRvqSPNIi2RigdVIRUQ%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#tbrzJ0avilgQmYSR4Ha11ZsJ%2FRvqSPNIi2RigdVIRUQ%3D"
+          }
+        }
+      ]
+    }
+  ], 
+  "elapsed_ms": 79
+}

--- a/codesearch/testdata/responses/a1dbf1dfbf5d6175fe544da6178c30ffa4796b78.json
+++ b/codesearch/testdata/responses/a1dbf1dfbf5d6175fe544da6178c30ffa4796b78.json
@@ -1,0 +1,117 @@
+{
+  "search_response": [
+    {
+      "maybe_skipped_documents": false, 
+      "hit_max_to_score": true, 
+      "estimated_total_number_of_results": 2, 
+      "search_result": [
+        {
+          "snippet": [
+            {
+              "text": {
+                "text": "// static\nvoid HttpAuth::ChooseBestChallenge(\n    HttpAuthHandlerFactory* http_auth_handler_factory,\n", 
+                "range": [
+                  {
+                    "range": {
+                      "start_line": 2, 
+                      "end_line": 2, 
+                      "start_column": 6, 
+                      "end_column": 35
+                    }, 
+                    "type": 41
+                  }
+                ]
+              }, 
+              "first_line_number": 24, 
+              "match_reason": {
+                "scoped_symbol": true
+              }, 
+              "scope": ""
+            }
+          ], 
+          "docid": "s6M3OlNaevU", 
+          "best_matching_line_number": 25, 
+          "language": "c++", 
+          "match_reason": {
+            "scoped_symbol": true
+          }, 
+          "full_history_search": false, 
+          "num_duplicates": 0, 
+          "top_file": {
+            "file": {
+              "changelist": "0", 
+              "name": "src/net/http/http_auth.cc", 
+              "package_name": "chromium", 
+              "revision": "0"
+            }
+          }, 
+          "has_unshown_matches": false, 
+          "num_matches": 1, 
+          "match": [
+            {
+              "line_number": 25, 
+              "score": 1026, 
+              "match_offset": 15, 
+              "match_length": 29, 
+              "line_text": "// static\nvoid HttpAuth::ChooseBestChallenge(\n    HttpAuthHandlerFactory* http_auth_handler_factory,\n"
+            }
+          ]
+        }, 
+        {
+          "snippet": [
+            {
+              "text": {
+                "text": "  // to use as appropriate.\n  static void ChooseBestChallenge(\n      HttpAuthHandlerFactory* http_auth_handler_factory,\n", 
+                "range": [
+                  {
+                    "range": {
+                      "start_line": 2, 
+                      "end_line": 2, 
+                      "start_column": 15, 
+                      "end_column": 34
+                    }, 
+                    "type": 41
+                  }
+                ]
+              }, 
+              "first_line_number": 137, 
+              "match_reason": {
+                "scoped_symbol": true
+              }, 
+              "scope": ""
+            }
+          ], 
+          "docid": "vz4-EVWRkJg", 
+          "best_matching_line_number": 138, 
+          "language": "c++", 
+          "match_reason": {
+            "scoped_symbol": true
+          }, 
+          "full_history_search": false, 
+          "num_duplicates": 0, 
+          "top_file": {
+            "file": {
+              "changelist": "0", 
+              "name": "src/net/http/http_auth.h", 
+              "package_name": "chromium", 
+              "revision": "0"
+            }
+          }, 
+          "has_unshown_matches": false, 
+          "num_matches": 1, 
+          "match": [
+            {
+              "line_number": 138, 
+              "score": 491, 
+              "match_offset": 42, 
+              "match_length": 19, 
+              "line_text": "  // to use as appropriate.\n  static void ChooseBestChallenge(\n      HttpAuthHandlerFactory* http_auth_handler_factory,\n"
+            }
+          ]
+        }
+      ], 
+      "results_offset": 0
+    }
+  ], 
+  "elapsed_ms": 67
+}

--- a/codesearch/testdata/responses/bc62cca9d61439e118900d1df34426fe5bf547c7.json
+++ b/codesearch/testdata/responses/bc62cca9d61439e118900d1df34426fe5bf547c7.json
@@ -1,0 +1,96 @@
+{
+  "elapsed_ms": 11, 
+  "xref_search_response": [
+    {
+      "status": 0, 
+      "estimated_total_type_count": [
+        {
+          "count": 2, 
+          "type": "DEFINITION", 
+          "type_id": 1
+        }, 
+        {
+          "count": 1, 
+          "type": "DECLARATION", 
+          "type_id": 2
+        }, 
+        {
+          "count": 2, 
+          "type": "REFERENCE", 
+          "type_id": 3
+        }
+      ], 
+      "kythe_next_page_token": "", 
+      "search_result": [
+        {
+          "match": [
+            {
+              "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%40755%3A774%40Nrxbg2wUMb7TnDHlFpxZyOQVIkRE3PT9Fb4TKk23Pqg%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+              "line_number": 25, 
+              "type_id": 1, 
+              "type": "DEFINITION", 
+              "line_text": "void HttpAuth::ChooseBestChallenge("
+            }, 
+            {
+              "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.cc#%40755%3A774%40Nrxbg2wUMb7TnDHlFpxZyOQVIkRE3PT9Fb4TKk23Pqg%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.cc", 
+              "line_number": 25, 
+              "type_id": 1, 
+              "type": "DEFINITION", 
+              "line_text": "void HttpAuth::ChooseBestChallenge("
+            }
+          ], 
+          "file": {
+            "name": "src/net/http/http_auth.cc", 
+            "package_name": "chromium"
+          }
+        }, 
+        {
+          "match": [
+            {
+              "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#%404802%3A4821%40YddxnghqOet%2BOOR1CG17TPUbhdiZwtDQLfDND%2Bk218g%3D%23chromium%23src%2Fnet%2Fhttp%2Fhttp_auth.h", 
+              "line_number": 138, 
+              "type_id": 2, 
+              "type": "DECLARATION", 
+              "line_text": "  static void ChooseBestChallenge("
+            }
+          ], 
+          "file": {
+            "name": "src/net/http/http_auth.h", 
+            "package_name": "chromium"
+          }
+        }, 
+        {
+          "match": [
+            {
+              "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_controller.cc#%4010227%3A10246", 
+              "line_number": 288, 
+              "type_id": 3, 
+              "type": "REFERENCE", 
+              "line_text": "      HttpAuth::ChooseBestChallenge(http_auth_handler_factory_, *headers,"
+            }
+          ], 
+          "file": {
+            "name": "src/net/http/http_auth_controller.cc", 
+            "package_name": "chromium"
+          }
+        }, 
+        {
+          "match": [
+            {
+              "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_unittest.cc#%405185%3A5204", 
+              "line_number": 143, 
+              "type_id": 3, 
+              "type": "REFERENCE", 
+              "line_text": "    HttpAuth::ChooseBestChallenge(http_auth_handler_factory.get(), *headers,"
+            }
+          ], 
+          "file": {
+            "name": "src/net/http/http_auth_unittest.cc", 
+            "package_name": "chromium"
+          }
+        }
+      ], 
+      "from_kythe": true
+    }
+  ]
+}

--- a/codesearch/testdata/responses/f24edc9489179ef61479b2c3b336ed5fe62af0cd.json
+++ b/codesearch/testdata/responses/f24edc9489179ef61479b2c3b336ed5fe62af0cd.json
@@ -1,0 +1,80 @@
+{
+  "elapsed_ms": 9, 
+  "call_graph_response": [
+    {
+      "node": {
+        "node_kind": "FUNCTION", 
+        "children": [
+          {
+            "call_scope_range": {
+              "start_line": 222, 
+              "end_line": 222, 
+              "start_column": 25, 
+              "end_column": 43
+            }, 
+            "package_name": "chromium", 
+            "snippet_package_name": "chromium", 
+            "call_site_range": {
+              "start_line": 288, 
+              "end_line": 290, 
+              "start_column": 7, 
+              "end_column": 74
+            }, 
+            "snippet": {
+              "text": {
+                "text": "      HttpAuth::ChooseBestChallenge(http_auth_handler_factory_, *headers,"
+              }, 
+              "first_line_number": 288
+            }, 
+            "snippet_file_path": "src/net/http/http_auth_controller.cc", 
+            "node_kind": "FUNCTION", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_controller.cc#GtcwscFl%2FOrKkHN649fanpArN6xKK%2BDVhhEx%2BfB2FAw%3D", 
+            "params": [
+              "headers", 
+              "ssl_info", 
+              "do_not_send_server_auth", 
+              "establishing_tunnel", 
+              "net_log"
+            ], 
+            "identifier": "HandleAuthChallenge", 
+            "file_path": "src/net/http/http_auth_controller.cc"
+          }, 
+          {
+            "call_scope_range": {
+              "start_line": 69, 
+              "end_line": 69, 
+              "start_column": 1, 
+              "end_column": 0
+            }, 
+            "package_name": "chromium", 
+            "snippet_package_name": "chromium", 
+            "call_site_range": {
+              "start_line": 143, 
+              "end_line": 146, 
+              "start_column": 5, 
+              "end_column": 43
+            }, 
+            "snippet": {
+              "text": {
+                "text": "    HttpAuth::ChooseBestChallenge(http_auth_handler_factory.get(), *headers,"
+              }, 
+              "first_line_number": 143
+            }, 
+            "snippet_file_path": "src/net/http/http_auth_unittest.cc", 
+            "node_kind": "FUNCTION", 
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_unittest.cc#vtn7oC2qNLbsyur%2FnHW4k29lNdRnYtP%2Ftori3r9RwRo%3D", 
+            "identifier": "TestBody", 
+            "file_path": "src/net/http/http_auth_unittest.cc"
+          }
+        ], 
+        "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#YddxnghqOet%2BOOR1CG17TPUbhdiZwtDQLfDND%2Bk218g%3D"
+      }, 
+      "is_from_kythe": true, 
+      "return_code": 1, 
+      "results_offset": 0, 
+      "estimated_total_number_results": 2, 
+      "is_call_graph": true, 
+      "kythe_next_page_token": ""
+    }
+  ]
+}


### PR DESCRIPTION
This change also updates the default set of arguments for a FileInfo lookup to include the outline information. The latter is now used for navigating the semantic structure of the code wherever necessary in lieu of the Xref types that went missing after the Kythe migration.