### PR TITLE
Moar compatibility fixes

### DIFF
--- a/codesearch/__main__.py
+++ b/codesearch/__main__.py
@@ -12,7 +12,6 @@ https://cs.chromium.org.
 from __future__ import absolute_import
 from __future__ import print_function
 
-
 import os
 import argparse
 import sys
@@ -113,7 +112,11 @@ common_args.add_argument(
 common_args.add_argument(
     '--loglevel', '-l', help='Log level', choices=['info', 'debug'])
 common_args.add_argument('--cache', '-C', help='Cache directory')
-common_args.add_argument('--root', '-r', action='store_true', help='Assume repository paths are relative to root')
+common_args.add_argument(
+    '--root',
+    '-r',
+    action='store_true',
+    help='Assume repository paths are relative to root')
 
 # sig
 signature_command = subcommands.add_parser(

--- a/codesearch/__main__.py
+++ b/codesearch/__main__.py
@@ -19,10 +19,18 @@ import sys
 import json
 import logging
 
-from codesearch import CodeSearch, CompoundRequest, \
-        CodeSearchProtoJsonSymbolizedEncoder, CodeSearchProtoJsonEncoder, \
-        XrefSearchRequest, SearchRequest, FileInfoRequest, DirInfoRequest, \
-        CallGraphRequest, EdgeEnumKind
+from codesearch import  \
+        CallGraphRequest, \
+        CodeSearch, \
+        CodeSearchProtoJsonEncoder, \
+        CodeSearchProtoJsonSymbolizedEncoder, \
+        CompoundRequest, \
+        DirInfoRequest, \
+        EdgeEnumKind, \
+        FileInfoRequest, \
+        Message, \
+        SearchRequest, \
+        XrefSearchRequest
 
 
 def print_result(results, args):

--- a/codesearch/__main__.py
+++ b/codesearch/__main__.py
@@ -10,6 +10,8 @@ https://cs.chromium.org.
 """
 
 from __future__ import absolute_import
+from __future__ import print_function
+
 
 import os
 import argparse
@@ -95,13 +97,15 @@ subgroup.add_argument(
 common_args = argparse.ArgumentParser(
     description='Common options', add_help=False)
 common_args.add_argument(
-    '--pretty',
+    '--nopretty',
     help='Whether to pretty print the resulting JSON',
     default=True,
-    action='store_true')
+    dest='pretty',
+    action='store_false')
 common_args.add_argument(
     '--loglevel', '-l', help='Log level', choices=['info', 'debug'])
 common_args.add_argument('--cache', '-C', help='Cache directory')
+common_args.add_argument('--root', '-r', action='store_true', help='Assume repository paths are relative to root')
 
 # sig
 signature_command = subcommands.add_parser(
@@ -257,10 +261,12 @@ codesearch_instance = None
 
 try:
   codesearch_instance = CodeSearch(
+      source_root='/' if arguments.root else None,
       a_path_inside_source_dir=os.getcwd(),
       cache_dir=arguments.cache if arguments.cache else None)
   setup_logging(codesearch_instance, arguments)
-  print_result(arguments.func(codesearch_instance, arguments), arguments)
+  result = arguments.func(codesearch_instance, arguments)
+  print_result(result, arguments)
 except Exception as e:
   print(e)
 finally:

--- a/codesearch/client_api.py
+++ b/codesearch/client_api.py
@@ -600,7 +600,7 @@ class CodeSearch(object):
       a_path_inside_source_dir=None,  # type: Optional[str]
       package_name='chromium',  # type: str
       codesearch_host='https://cs.chromium.org',  # type: str
-      request_timeout_in_seconds=3,  # type: int
+      request_timeout_in_seconds=10,  # type: int
       user_agent_string='Python-CodeSearch-Client'  # type: str
   ):
     # type: (...) -> None
@@ -611,6 +611,7 @@ class CodeSearch(object):
     backened depend on it.
 
     Arguments:
+
         should_cache -- Should be set to True in order to use a disk cache. See
             documentation for cache_dir for how the cache is organized.
 
@@ -791,7 +792,6 @@ class CodeSearch(object):
     # type: (str, int) -> CompoundResponse
     """Retrieves a list of call graph nodes corresponding to all call sites of
     |signature|.
-
     """
     return self.SendRequestToServer(
         CompoundRequest(call_graph_request=[

--- a/codesearch/client_api.py
+++ b/codesearch/client_api.py
@@ -44,7 +44,7 @@ from .paths import GetSourceRoot
 from .compat import StringFromBytes
 from .language_utils import SymbolSuffixMatcher, IsIdentifier
 
-if sys.version_info >= (3,0):
+if sys.version_info >= (3, 0):
   from urllib.request import urlopen, Request
   from urllib.parse import urlencode, urlparse, unquote
 else:

--- a/codesearch/client_api.py
+++ b/codesearch/client_api.py
@@ -601,7 +601,7 @@ class CodeSearch(object):
       package_name='chromium',  # type: str
       codesearch_host='https://cs.chromium.org',  # type: str
       request_timeout_in_seconds=10,  # type: int
-      user_agent_string='Python-CodeSearch-Client'  # type: str
+      user_agent_string='Python-CodeSearch-Client (https://github.com/chromium/codesearch-py)'  # type: str
   ):
     # type: (...) -> None
     """Initialize a CodeSearch object.

--- a/codesearch/messages.py
+++ b/codesearch/messages.py
@@ -32,9 +32,21 @@ class CodeSearchProtoJsonSymbolizedEncoder(json.JSONEncoder):
       rv = {}
       desc = o.__class__.DESCRIPTOR
       for k, v in o.__dict__.items():
-        if k in desc and not isinstance(desc[k], list) and issubclass(
-            desc[k], Message) and desc[k].IsEnum():
-          rv[k] = desc[k].ToSymbol(v)
+        if k in desc:
+          if not isinstance(desc[k], list) and \
+              issubclass(desc[k], Message) and \
+              desc[k].IsEnum():
+            rv[k] = desc[k].ToSymbol(v)
+          elif desc[k] == str and IsString(v) and not v:
+            pass
+          elif isinstance(desc[k], list) and \
+              isinstance(v, list) and \
+              len(v) == 0:
+            pass
+          elif v is None:
+            pass
+          else:
+            rv[k] = v
         else:
           rv[k] = v
       return rv

--- a/codesearch/messages.py
+++ b/codesearch/messages.py
@@ -1105,7 +1105,7 @@ class Node(Message):
     self.node_kind = d.get('node_kind', int)  # type: int
     self.override = d.get('override', bool())  # type: bool
     self.package_name = d.get('package_name', str())  # type: str
-    self.params = d.get('params', [str])  # type: [str]
+    self.params = d.get('params', [])  # type: [str]
     self.signature = d.get('signature', str())  # type: str
     self.snippet = d.get('snippet', Snippet())  # type: Snippet
     self.snippet_file_path = d.get('snippet_file_path', str())  # type: str

--- a/codesearch/messages.py
+++ b/codesearch/messages.py
@@ -1566,6 +1566,7 @@ class SearchResult(Message):
       'children': [str],
       'docid': str,
       'duplicate': [FileResult],
+      'full_history_search': bool,
       'has_unshown_matches': bool,
       'hit_max_matches': bool,
       'is_augmented': bool,
@@ -1606,6 +1607,7 @@ class SearchResponse(Message):
       'hit_max_results': bool,
       'hit_max_to_score': bool,
       'maybe_skipped_documents': bool,
+      'next_page_token': str,
       'results_offset': int,
       'search_result': [SearchResult],
       'status': int,
@@ -1631,15 +1633,21 @@ class SearchResponse(Message):
 class SearchRequest(Message):
   DESCRIPTOR = {
       'exhaustive': bool,
+      'file_sizes': bool,
+      'full_history_search': bool,
       'lines_context': int,
       'max_num_results': int,
+      'page_token': str,
       'query': str,
+      'results_offset': int,
       'return_all_duplicates': bool,
       'return_all_snippets': bool,
+      'return_local_augmented_results': bool,
       'return_decorated_snippets': bool,
       'return_directories': bool,
       'return_line_matches': bool,
       'return_snippets': bool,
+      'sort_results': bool,
   }
 
   def __init__(self, **kwargs):

--- a/codesearch/messages.py
+++ b/codesearch/messages.py
@@ -1149,7 +1149,7 @@ class CallGraphRequest(Message):
   def __init__(self, **kwargs):
     d = kwargs
     self.file_spec = d.get('file_spec', FileSpec())  # type: FileSpec
-    self.max_num_results = d.get('max_num_results', int())  # type: int
+    self.max_num_results = d.get('max_num_results', 100))  # type: int
     self.signature = d.get('signature', str())  # type: str
 
 
@@ -1363,8 +1363,6 @@ class XrefSearchResponse(Message):
     self.from_kythe = d.get('from_kythe', bool())  # type: bool
     self.kythe_next_page_token = d.get('kythe_next_page_token',
                                        str())  # type: str
-    self.grok_total_number_of_results = d.get('grok_total_number_of_results',
-                                              int())  # type: int
     self.search_result = d.get('search_result',
                                [])  # type: List[XrefSearchResult]
     self.status = d.get('status', int())  # type: int
@@ -1382,7 +1380,7 @@ class XrefSearchRequest(Message):
   def __init__(self, **kwargs):
     d = kwargs
     self.file_spec = d.get('file_spec', FileSpec())  # type: FileSpec
-    self.max_num_results = d.get('max_num_results', int())  # type: int
+    self.max_num_results = d.get('max_num_results', 100)  # type: int
     self.query = d.get('query', str())  # type: str
 
 
@@ -1654,7 +1652,7 @@ class SearchRequest(Message):
     d = kwargs
     self.exhaustive = d.get('exhaustive', bool())  # type: bool
     self.lines_context = d.get('lines_context', int())  # type: int
-    self.max_num_results = d.get('max_num_results', int())  # type: int
+    self.max_num_results = d.get('max_num_results', 100)  # type: int
     self.query = d.get('query', str())  # type: str
     self.return_all_duplicates = d.get('return_all_duplicates',
                                        bool())  # type: bool
@@ -1681,6 +1679,7 @@ class CompoundResponse(Message):
       'search_response': [SearchResponse],
       'status_response': [StatusResponse],
       'xref_search_response': [XrefSearchResponse],
+      'elapsed_ms': int,  # Time taken to process request.
   }
 
   def __init__(self, **kwargs):
@@ -1700,6 +1699,7 @@ class CompoundResponse(Message):
     self.xref_search_response = d.get(
         'xref_search_response',
         None)  # type: Optional[List[XrefSearchResponse]]
+    self.elapsed_ms = d.get('elapsed_ms', 0)
 
 
 class CompoundRequest(Message):

--- a/codesearch/messages.py
+++ b/codesearch/messages.py
@@ -1149,7 +1149,7 @@ class CallGraphRequest(Message):
   def __init__(self, **kwargs):
     d = kwargs
     self.file_spec = d.get('file_spec', FileSpec())  # type: FileSpec
-    self.max_num_results = d.get('max_num_results', 100))  # type: int
+    self.max_num_results = d.get('max_num_results', 100)  # type: int
     self.signature = d.get('signature', str())  # type: str
 
 

--- a/codesearch/messages.py
+++ b/codesearch/messages.py
@@ -321,7 +321,14 @@ class TextRange(Message):
     return True
 
   def IsValid(self):
-    return self.start_line != 0 or self.start_column != 0 or self.end_line != 0 or self.end_column != 0
+    return \
+        self.start_line != 0 or \
+        self.start_column != 0 or \
+        self.end_line != 0 or \
+        self.end_column != 0
+
+  def Empty(self):
+    return not self.IsValid()
 
   def __eq__(self, other):
     if not isinstance(other, TextRange):
@@ -715,6 +722,10 @@ class AnnotatedText(Message):
     self.text = d.get('text', str())  # type: str
     self.range = d.get('range', [])  # type: [FormatRange]
 
+  def Empty(self):
+    # type: () -> bool
+    return self.text == ""
+
 
 class CodeBlockType(Message):
   DESCRIPTOR = int
@@ -1040,6 +1051,10 @@ class Snippet(Message):
                               MatchReason())  # type: MatchReason
     self.scope = d.get('scope', str())  # type: str
     self.text = d.get('text', AnnotatedText())  # type: AnnotatedText
+
+  def Empty(self):
+    # type: () -> bool
+    return self.first_line_number == 0 or self.text.Empty()
 
 
 class Node(Message):

--- a/codesearch/test_client_api.py
+++ b/codesearch/test_client_api.py
@@ -47,8 +47,8 @@ class TestCodeSearch(unittest.TestCase):
 
     request = LastRequest()
     self.assertIsNotNone(request)
-    self.assertEqual('Python-CodeSearch-Client',
-                     request.get_header('User-agent'))
+    self.assertTrue(
+        request.get_header('User-agent').startswith('Python-CodeSearch-Client'))
 
     codesearch = CodeSearch(source_root=SOURCE_ROOT, user_agent_string='Foo')
     codesearch.GetAnnotationsForFile(TARGET_FILE)

--- a/codesearch/testdata/compound_response_01.json
+++ b/codesearch/testdata/compound_response_01.json
@@ -1,0 +1,358 @@
+{
+  "call_graph_response": [
+    {
+      "return_code": 1,
+      "node": {
+        "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler.h#JeFRw996xZZVV9czj%2FFb1cDpm3lK9KygMuH3I5j8Gvs%3D",
+        "node_kind": "FUNCTION",
+        "children": [
+          {
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_controller.cc#KT6dW2Oyiv3OtfDK3Auh0pjK2V2ZCCzASfU34HIjU1A%3D",
+            "file_path": "src/net/http/http_auth_controller.cc",
+            "package_name": "chromium",
+            "node_kind": "FUNCTION",
+            "identifier": "MaybeGenerateAuthToken",
+            "snippet": {
+              "text": {
+                "text": "  int rv = handler_->GenerateAuthToken("
+              },
+              "first_line_number": 159
+            },
+            "call_site_range": {
+              "start_line": 159,
+              "start_column": 12,
+              "end_line": 163,
+              "end_column": 19
+            },
+            "call_scope_range": {
+              "start_line": 145,
+              "start_column": 25,
+              "end_line": 145,
+              "end_column": 46
+            },
+            "params": [
+              "request",
+              "callback",
+              "net_log"
+            ],
+            "snippet_file_path": "src/net/http/http_auth_controller.cc",
+            "snippet_package_name": "chromium"
+          },
+          {
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler_basic_unittest.cc#rGyD7PGS8PcACbNF5dm7cMXAM6Dsg2C7f2H2w45x0Xo%3D",
+            "file_path": "src/net/http/http_auth_handler_basic_unittest.cc",
+            "package_name": "chromium",
+            "node_kind": "FUNCTION",
+            "identifier": "TestBody",
+            "snippet": {
+              "text": {
+                "text": "    int rv = basic->GenerateAuthToken(&credentials, &request_info,"
+              },
+              "first_line_number": 54
+            },
+            "call_site_range": {
+              "start_line": 54,
+              "start_column": 14,
+              "end_line": 55,
+              "end_column": 71
+            },
+            "call_scope_range": {
+              "start_line": 26,
+              "start_column": 1,
+              "end_line": 26,
+              "end_column": 0
+            },
+            "snippet_file_path": "src/net/http/http_auth_handler_basic_unittest.cc",
+            "snippet_package_name": "chromium"
+          },
+          {
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler_digest_unittest.cc#NWXPUm5fOZr6UiWzw8QJpbFF8qT%2Bbs0%2FWxz%2Bz6rxCAE%3D",
+            "file_path": "src/net/http/http_auth_handler_digest_unittest.cc",
+            "package_name": "chromium",
+            "node_kind": "FUNCTION",
+            "identifier": "RespondToChallenge",
+            "snippet": {
+              "text": {
+                "text": "  int rv_generate = handler->GenerateAuthToken("
+              },
+              "first_line_number": 80
+            },
+            "call_site_range": {
+              "start_line": 80,
+              "start_column": 21,
+              "end_line": 81,
+              "end_column": 62
+            },
+            "call_scope_range": {
+              "start_line": 38,
+              "start_column": 6,
+              "end_line": 38,
+              "end_column": 23
+            },
+            "params": [
+              "target",
+              "proxy_name",
+              "request_url",
+              "challenge",
+              "token"
+            ],
+            "snippet_file_path": "src/net/http/http_auth_handler_digest_unittest.cc",
+            "snippet_package_name": "chromium"
+          },
+          {
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler_negotiate_unittest.cc#K4ikCIS9mEQ2mHfCRGMW5LQewkaTRwkdAaRECIIEiX8%3D",
+            "file_path": "src/net/http/http_auth_handler_negotiate_unittest.cc",
+            "package_name": "chromium",
+            "node_kind": "FUNCTION",
+            "identifier": "TestBody",
+            "snippet": {
+              "text": {
+                "text": "  EXPECT_EQ(OK, callback.GetResult(auth_handler->GenerateAuthToken("
+              },
+              "first_line_number": 257
+            },
+            "call_site_range": {
+              "start_line": 257,
+              "start_column": 3,
+              "end_line": 257,
+              "end_column": 2
+            },
+            "call_scope_range": {
+              "start_line": 247,
+              "start_column": 1,
+              "end_line": 247,
+              "end_column": 0
+            },
+            "snippet_file_path": "src/net/http/http_auth_handler_negotiate_unittest.cc",
+            "snippet_package_name": "chromium"
+          },
+          {
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler_negotiate_unittest.cc#VfqfOw7DzVIjSOvfAoZkrsRnILsU2svoU3J3QXGEKdE%3D",
+            "file_path": "src/net/http/http_auth_handler_negotiate_unittest.cc",
+            "package_name": "chromium",
+            "node_kind": "FUNCTION",
+            "identifier": "TestBody",
+            "snippet": {
+              "text": {
+                "text": "  EXPECT_EQ(OK, callback.GetResult(auth_handler->GenerateAuthToken("
+              },
+              "first_line_number": 275
+            },
+            "call_site_range": {
+              "start_line": 275,
+              "start_column": 3,
+              "end_line": 275,
+              "end_column": 2
+            },
+            "call_scope_range": {
+              "start_line": 266,
+              "start_column": 1,
+              "end_line": 266,
+              "end_column": 0
+            },
+            "snippet_file_path": "src/net/http/http_auth_handler_negotiate_unittest.cc",
+            "snippet_package_name": "chromium"
+          },
+          {
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler_negotiate_unittest.cc#MazmFIKzSqLuiLofsfY1tlOdgXUaTXxd8SccEVJ9HWw%3D",
+            "file_path": "src/net/http/http_auth_handler_negotiate_unittest.cc",
+            "package_name": "chromium",
+            "node_kind": "FUNCTION",
+            "identifier": "TestBody",
+            "snippet": {
+              "text": {
+                "text": "  EXPECT_EQ(OK, callback.GetResult(auth_handler->GenerateAuthToken("
+              },
+              "first_line_number": 293
+            },
+            "call_site_range": {
+              "start_line": 293,
+              "start_column": 3,
+              "end_line": 293,
+              "end_column": 2
+            },
+            "call_scope_range": {
+              "start_line": 284,
+              "start_column": 1,
+              "end_line": 284,
+              "end_column": 0
+            },
+            "snippet_file_path": "src/net/http/http_auth_handler_negotiate_unittest.cc",
+            "snippet_package_name": "chromium"
+          },
+          {
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler_negotiate_unittest.cc#g7ofIg8EBdx3S%2Bg8ITGeYjzFy5DEXZ4SDF5UPD7BpcI%3D",
+            "file_path": "src/net/http/http_auth_handler_negotiate_unittest.cc",
+            "package_name": "chromium",
+            "node_kind": "FUNCTION",
+            "identifier": "TestBody",
+            "snippet": {
+              "text": {
+                "text": "  EXPECT_EQ(OK, callback.GetResult(auth_handler->GenerateAuthToken("
+              },
+              "first_line_number": 311
+            },
+            "call_site_range": {
+              "start_line": 311,
+              "start_column": 3,
+              "end_line": 311,
+              "end_column": 2
+            },
+            "call_scope_range": {
+              "start_line": 302,
+              "start_column": 1,
+              "end_line": 302,
+              "end_column": 0
+            },
+            "snippet_file_path": "src/net/http/http_auth_handler_negotiate_unittest.cc",
+            "snippet_package_name": "chromium"
+          },
+          {
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler_negotiate_unittest.cc#7FHB99jS0bE%2BoVdt265ONAIqYAdc4DR5kppiAcF0YSE%3D",
+            "file_path": "src/net/http/http_auth_handler_negotiate_unittest.cc",
+            "package_name": "chromium",
+            "node_kind": "FUNCTION",
+            "identifier": "TestBody",
+            "snippet": {
+              "text": {
+                "text": "  EXPECT_EQ(ERR_IO_PENDING, auth_handler->GenerateAuthToken("
+              },
+              "first_line_number": 329
+            },
+            "call_site_range": {
+              "start_line": 329,
+              "start_column": 3,
+              "end_line": 329,
+              "end_column": 2
+            },
+            "call_scope_range": {
+              "start_line": 320,
+              "start_column": 1,
+              "end_line": 320,
+              "end_column": 0
+            },
+            "snippet_file_path": "src/net/http/http_auth_handler_negotiate_unittest.cc",
+            "snippet_package_name": "chromium"
+          },
+          {
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler_negotiate_unittest.cc#Rrtf%2FzL8yfwFbA8Xf%2B5Q6%2FnOxpoky4ikgHiK7MnTTVE%3D",
+            "file_path": "src/net/http/http_auth_handler_negotiate_unittest.cc",
+            "package_name": "chromium",
+            "node_kind": "FUNCTION",
+            "identifier": "TestBody",
+            "snippet": {
+              "text": {
+                "text": "  EXPECT_EQ(ERR_IO_PENDING, auth_handler->GenerateAuthToken("
+              },
+              "first_line_number": 352
+            },
+            "call_site_range": {
+              "start_line": 352,
+              "start_column": 3,
+              "end_line": 352,
+              "end_column": 2
+            },
+            "call_scope_range": {
+              "start_line": 343,
+              "start_column": 1,
+              "end_line": 343,
+              "end_column": 0
+            },
+            "snippet_file_path": "src/net/http/http_auth_handler_negotiate_unittest.cc",
+            "snippet_package_name": "chromium"
+          },
+          {
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler_negotiate_unittest.cc#d7IMoCLUefiYaXMDOaxLMz2FMx7QtVnkwNSfvTNNtxc%3D",
+            "file_path": "src/net/http/http_auth_handler_negotiate_unittest.cc",
+            "package_name": "chromium",
+            "node_kind": "FUNCTION",
+            "identifier": "TestBody",
+            "snippet": {
+              "text": {
+                "text": "  EXPECT_EQ(ERR_IO_PENDING, auth_handler->GenerateAuthToken("
+              },
+              "first_line_number": 368
+            },
+            "call_site_range": {
+              "start_line": 368,
+              "start_column": 3,
+              "end_line": 368,
+              "end_column": 2
+            },
+            "call_scope_range": {
+              "start_line": 359,
+              "start_column": 1,
+              "end_line": 359,
+              "end_column": 0
+            },
+            "snippet_file_path": "src/net/http/http_auth_handler_negotiate_unittest.cc",
+            "snippet_package_name": "chromium"
+          },
+          {
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler_ntlm_portable_unittest.cc#MLDmQc3F5wGTwKNVa06Shcenysy7X%2FMfsWLA3KgPVt4%3D",
+            "file_path": "src/net/http/http_auth_handler_ntlm_portable_unittest.cc",
+            "package_name": "chromium",
+            "node_kind": "FUNCTION",
+            "identifier": "GenerateAuthToken",
+            "snippet": {
+              "text": {
+                "text": "    return callback.GetResult(GetAuthHandler()->GenerateAuthToken("
+              },
+              "first_line_number": 82
+            },
+            "call_site_range": {
+              "start_line": 82,
+              "start_column": 31,
+              "end_line": 83,
+              "end_column": 62
+            },
+            "call_scope_range": {
+              "start_line": 79,
+              "start_column": 7,
+              "end_line": 79,
+              "end_column": 23
+            },
+            "params": [
+              "token"
+            ],
+            "snippet_file_path": "src/net/http/http_auth_handler_ntlm_portable_unittest.cc",
+            "snippet_package_name": "chromium"
+          },
+          {
+            "signature": "kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth_handler_unittest.cc#GA%2Bgg3Wjb9br4%2BfIxRALnWq0B%2BIzV4PD4r7%2FPajlk9Y%3D",
+            "file_path": "src/net/http/http_auth_handler_unittest.cc",
+            "package_name": "chromium",
+            "node_kind": "FUNCTION",
+            "identifier": "TestBody",
+            "snippet": {
+              "text": {
+                "text": "        mock_handler.GenerateAuthToken(&credentials, &request,"
+              },
+              "first_line_number": 56
+            },
+            "call_site_range": {
+              "start_line": 56,
+              "start_column": 9,
+              "end_line": 57,
+              "end_column": 77
+            },
+            "call_scope_range": {
+              "start_line": 25,
+              "start_column": 1,
+              "end_line": 25,
+              "end_column": 0
+            },
+            "snippet_file_path": "src/net/http/http_auth_handler_unittest.cc",
+            "snippet_package_name": "chromium"
+          }
+        ]
+      },
+      "estimated_total_number_results": 12,
+      "results_offset": 0,
+      "is_call_graph": true,
+      "kythe_next_page_token": "",
+      "is_from_kythe": true
+    }
+  ],
+  "elapsed_ms": 28
+}

--- a/codesearch/testing_support.py
+++ b/codesearch/testing_support.py
@@ -26,7 +26,7 @@ RESPONSE_DATA_DIR = os.path.join(TEST_DATA_DIR, 'responses')
 
 disable_network = False
 
-if sys.version_info < (3,0):
+if sys.version_info < (3, 0):
   # Python 2
   from urllib2 import urlopen, Request, HTTPSHandler, install_opener, build_opener, addinfourl, URLError
   from urlparse import urlparse, parse_qsl, parse_qs, urlunparse


### PR DESCRIPTION
Notable changes here include:

- Increase default request timeouts to 10 seconds from the previous 3 seconds. The backend now regularly times out without this.
- Update the `User-Agent` string to include a link to the project page in case anyone is wondering where these requests come from.
- Gracefully handle recognized enum values.
- Set the `max_num_results` parameter explicitly to a modest value. The default value of zero causes the backend to reject the request, perhaps correctly.
