### PR TITLE
Switch to PEP-8 for code style.

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,2 +1,3 @@
 [style]
-based_on_style = chromium
+based_on_style = pep8
+column_limit = 80

--- a/codesearch/__init__.py
+++ b/codesearch/__init__.py
@@ -13,6 +13,10 @@ from .client_api import \
     ServerError, \
     XrefNode
 
+__all__ = [
+    "CodeSearch", "NoFileSpecError", "NotFoundError", "ServerError", "XrefNode"
+]
+
 from .messages import \
     AnnotatedText, \
     Annotation,  \
@@ -63,13 +67,33 @@ from .messages import \
     XrefSingleMatch,  \
     XrefTypeCount
 
+__all__ += [
+    "AnnotatedText", "Annotation", "AnnotationResponse", "AnnotationType",
+    "AnnotationTypeValue", "CallGraphRequest", "CallGraphResponse", "CodeBlock",
+    "CodeBlockType", "CodeSearchProtoJsonEncoder",
+    "CodeSearchProtoJsonSymbolizedEncoder", "CompoundRequest",
+    "CompoundResponse", "DirInfoRequest", "DirInfoResponse",
+    "DirInfoResponseChild", "EdgeEnumKind", "FileInfo", "FileInfoRequest",
+    "FileInfoResponse", "FileResult", "FileSpec", "FormatRange", "FormatType",
+    "GobInfo", "InternalLink", "InternalPackage", "KytheNodeKind",
+    "KytheXrefKind", "MatchReason", "Message", "Modifiers", "Node",
+    "NodeEnumKind", "SearchRequest", "SearchResponse", "SearchResult",
+    "SingleMatch", "Snippet", "StatusRequest", "StatusResponse",
+    "VanityGitOnBorgHostname", "XrefSearchRequest", "XrefSearchResponse",
+    "XrefSearchResult", "XrefSignature", "XrefSingleMatch", "XrefTypeCount"
+]
+
 from .paths import \
     GetPackageRelativePath, \
     GetSourceRoot, \
-    NoSourceRootError
+    NoSourceRootError  # noqa: E402
+
+__all__ += ["GetPackageRelativePath", "GetSourceRoot", "NoSourceRootError"]
 
 # Only useful for testing against this library.
 from .testing_support import \
     DisableNetwork, \
     EnableNetwork, \
-    InstallTestRequestHandler
+    InstallTestRequestHandler  # noqa: E402
+
+__all__ += ["DisableNetwork", "EnableNetwork", "InstallTestRequestHandler"]

--- a/codesearch/__main__.py
+++ b/codesearch/__main__.py
@@ -19,61 +19,59 @@ import json
 import logging
 
 from codesearch import  \
-        CallGraphRequest, \
-        CodeSearch, \
-        CodeSearchProtoJsonEncoder, \
-        CodeSearchProtoJsonSymbolizedEncoder, \
-        CompoundRequest, \
-        DirInfoRequest, \
-        EdgeEnumKind, \
-        FileInfoRequest, \
-        Message, \
-        SearchRequest, \
-        XrefSearchRequest
+    CallGraphRequest, \
+    CodeSearch, \
+    CodeSearchProtoJsonEncoder, \
+    CodeSearchProtoJsonSymbolizedEncoder, \
+    CompoundRequest, \
+    DirInfoRequest, \
+    EdgeEnumKind, \
+    FileInfoRequest, \
+    SearchRequest, \
+    XrefSearchRequest
 
 
 def print_result(results, args):
-  if args.pretty:
-    print(json.dumps(
-        results,
-        indent=4,
-        ensure_ascii=True,
-        cls=CodeSearchProtoJsonSymbolizedEncoder))
-  else:
-    print(json.dumps(results, cls=CodeSearchProtoJsonEncoder))
+    if args.pretty:
+        print(
+            json.dumps(results,
+                       indent=4,
+                       ensure_ascii=True,
+                       cls=CodeSearchProtoJsonSymbolizedEncoder))
+    else:
+        print(json.dumps(results, cls=CodeSearchProtoJsonEncoder))
 
 
 def get_signature(cs, args):
-  if args.signature:
-    return args.signature
+    if args.signature:
+        return args.signature
 
-  if not (args.path and args.word):
-    print('Both PATH and WORD must be specified')
-    sys.exit(2)
+    if not (args.path and args.word):
+        print('Both PATH and WORD must be specified')
+        sys.exit(2)
 
-  return cs.GetSignatureForSymbol(args.path, args.word)
+    return cs.GetSignatureForSymbol(args.path, args.word)
 
 
 def setup_logging(cs, args):
-  if args.loglevel:
-    if args.loglevel == 'info':
-      level = logging.INFO
-    else:
-      level = logging.DEBUG
-    cs.GetLogger().setLevel(level)
-    logging.basicConfig()
+    if args.loglevel:
+        if args.loglevel == 'info':
+            level = logging.INFO
+        else:
+            level = logging.DEBUG
+        cs.GetLogger().setLevel(level)
+        logging.basicConfig()
 
 
 def get_edge_filter(args):
-  if args.all:
-    return [
-        getattr(EdgeEnumKind, x)
-        for x in vars(EdgeEnumKind)
-        if isinstance(getattr(EdgeEnumKind, x), int)
-    ]
-  if args.type:
-    return args.type
-  return []
+    if args.all:
+        return [
+            getattr(EdgeEnumKind, x) for x in vars(EdgeEnumKind)
+            if isinstance(getattr(EdgeEnumKind, x), int)
+        ]
+    if args.type:
+        return args.type
+    return []
 
 
 parser = argparse.ArgumentParser(description=__doc__)
@@ -92,31 +90,30 @@ subgroup.add_argument('-p', '--path', help='Path to file.')
 subgroup.add_argument(
     '-w',
     '--word',
-    help=
-    '''The word to search for in the file denoted by the path argument. You must
-    also specify -p''')
+    help='The word to search for in the file denoted by the path argument. You '
+    'must also specify -p')
 subgroup.add_argument(
     '-s',
     '--signature',
-    help='''A signature provided from a previous search. No -p or -w arguments
-    required.''')
+    help='A signature provided from a previous search. No -p or -w arguments '
+    'required.')
 
-common_args = argparse.ArgumentParser(
-    description='Common options', add_help=False)
-common_args.add_argument(
-    '--nopretty',
-    help='Whether to pretty print the resulting JSON',
-    default=True,
-    dest='pretty',
-    action='store_false')
-common_args.add_argument(
-    '--loglevel', '-l', help='Log level', choices=['info', 'debug'])
+common_args = argparse.ArgumentParser(description='Common options',
+                                      add_help=False)
+common_args.add_argument('--nopretty',
+                         help='Whether to pretty print the resulting JSON',
+                         default=True,
+                         dest='pretty',
+                         action='store_false')
+common_args.add_argument('--loglevel',
+                         '-l',
+                         help='Log level',
+                         choices=['info', 'debug'])
 common_args.add_argument('--cache', '-C', help='Cache directory')
-common_args.add_argument(
-    '--root',
-    '-r',
-    action='store_true',
-    help='Assume repository paths are relative to root')
+common_args.add_argument('--root',
+                         '-r',
+                         action='store_true',
+                         help='Assume repository paths are relative to root')
 
 # sig
 signature_command = subcommands.add_parser(
@@ -129,37 +126,33 @@ xrefs_command = subcommands.add_parser(
     'xrefs',
     help='Query cross-references',
     parents=[signature_specifiers, common_args])
-xrefs_command.add_argument(
-    '--all', '-A', help='Include all outgoing references', action='store_true')
-xrefs_command.add_argument(
-    '--type', '-T', help='Include references of this type', action='append')
+xrefs_command.add_argument('--all',
+                           '-A',
+                           help='Include all outgoing references',
+                           action='store_true')
+xrefs_command.add_argument('--type',
+                           '-T',
+                           help='Include references of this type',
+                           action='append')
 xrefs_command.set_defaults(func=lambda cs, a: cs.SendRequestToServer(
-    CompoundRequest(
-        xref_search_request=[
-            XrefSearchRequest(
-                query=get_signature(cs, a),
-                file_spec=cs.GetFileSpec('.'),
-                edge_filter=get_edge_filter(a),
-                max_num_results=100
-            )
-        ]
-    )))
+    CompoundRequest(xref_search_request=[
+        XrefSearchRequest(query=get_signature(cs, a),
+                          file_spec=cs.GetFileSpec('.'),
+                          edge_filter=get_edge_filter(a),
+                          max_num_results=100)
+    ])))
 
 # callers
 callers_command = subcommands.add_parser(
     'callers',
     help='Query callers for a signature',
     parents=[signature_specifiers, common_args])
-callers_command.set_defaults(
-    func=lambda cs, a: cs.SendRequestToServer(
-        CompoundRequest(
-            call_graph_request=[
-                CallGraphRequest(
-                    signature=get_signature(cs, a),
-                    file_spec=cs.GetFileSpec('.'),
-                    max_num_results=100)
-            ]
-        )))
+callers_command.set_defaults(func=lambda cs, a: cs.SendRequestToServer(
+    CompoundRequest(call_graph_request=[
+        CallGraphRequest(signature=get_signature(cs, a),
+                         file_spec=cs.GetFileSpec('.'),
+                         max_num_results=100)
+    ])))
 
 # annot
 annotate_command = subcommands.add_parser(
@@ -174,112 +167,98 @@ annotate_command.add_argument(
     choices=['LINK_TO_DEFINITION', 'LINK_TO_URL', 'XREF_SIGNATURE'],
     default=['LINK_TO_DEFINITION', 'XREF_SIGNATURE'])
 annotate_command.set_defaults(
-    func=lambda cs, a: cs.GetAnnotationsForFile(
-        a.path, [{'id': x} for x in a.type]))
+    func=lambda cs, a: cs.GetAnnotationsForFile(a.path, [{
+        'id': x
+    } for x in a.type]))
 
 # file_info
 file_info_command = subcommands.add_parser(
     'fileinfo', help='Get file info', parents=[path_specifiers, common_args])
-file_info_command.add_argument(
-    '--outline',
-    '-o',
-    help='Get outlining metadata.',
-    default=False,
-    action='store_true')
-file_info_command.add_argument(
-    '--html', '-H', help='Get HTML.', default=False, action='store_true')
-file_info_command.add_argument(
-    '--folding',
-    '-f',
-    help='Get folding metadata.',
-    default=False,
-    action='store_true')
-file_info_command.set_defaults(
-    func=lambda cs, a: cs.SendRequestToServer(
-        CompoundRequest(
-            file_info_request=[
-                FileInfoRequest(
-                    file_spec=cs.GetFileSpec(a.path),
-                    fetch_html_content=a.html,
-                    fetch_outline=a.outline,
-                    fetch_folding=a.folding,
-                    fetch_generated_from=False
-                )
-            ]
-        )))
+file_info_command.add_argument('--outline',
+                               '-o',
+                               help='Get outlining metadata.',
+                               default=False,
+                               action='store_true')
+file_info_command.add_argument('--html',
+                               '-H',
+                               help='Get HTML.',
+                               default=False,
+                               action='store_true')
+file_info_command.add_argument('--folding',
+                               '-f',
+                               help='Get folding metadata.',
+                               default=False,
+                               action='store_true')
+file_info_command.set_defaults(func=lambda cs, a: cs.SendRequestToServer(
+    CompoundRequest(file_info_request=[
+        FileInfoRequest(file_spec=cs.GetFileSpec(a.path),
+                        fetch_html_content=a.html,
+                        fetch_outline=a.outline,
+                        fetch_folding=a.folding,
+                        fetch_generated_from=False)
+    ])))
 
 # dir_info
 dir_info_command = subcommands.add_parser(
     'dirinfo',
     help='Get directory info',
     parents=[path_specifiers, common_args])
-dir_info_command.set_defaults(
-    func=lambda cs, a: cs.SendRequestToServer(
-        CompoundRequest(
-            dir_info_request=[
-                DirInfoRequest(
-                    file_spec=cs.GetFileSpec(a.path)
-                )
-            ]
-        )))
+dir_info_command.set_defaults(func=lambda cs, a: cs.SendRequestToServer(
+    CompoundRequest(dir_info_request=                               # noqa: E251
+                    [DirInfoRequest(file_spec=cs.GetFileSpec(a.path))])))
 
 # search
-search_command = subcommands.add_parser(
-    'q', help='Search', parents=[common_args])
+search_command = subcommands.add_parser('q',
+                                        help='Search',
+                                        parents=[common_args])
 search_command.add_argument('query', help='Search terms.', metavar='QUERY')
-search_command.add_argument(
-    '--max_results',
-    '-N',
-    help='Maximum number of results to return.',
-    type=int,
-    default=50)
-search_command.add_argument(
-    '--snippets', '-S', help='Include snippets.', action='store_true')
-search_command.add_argument(
-    '--decorate',
-    '-D',
-    help='Decorate snippets with syntactic hints',
-    action='store_true')
-search_command.add_argument(
-    '--context',
-    '-U',
-    help='Lines of context to inclued in snippets.',
-    type=int,
-    default=3)
-search_command.set_defaults(
-    func=lambda cs, a: cs.SendRequestToServer(
-        CompoundRequest(
-            search_request=[
-                SearchRequest(
-                    query=a.query,
-                    return_snippets=(a.snippets or a.decorate),
-                    return_decorated_snippets=a.decorate,
-                    max_num_results=a.max_results,
-                    lines_context=a.context
-                )
-            ]
-        )))
+search_command.add_argument('--max_results',
+                            '-N',
+                            help='Maximum number of results to return.',
+                            type=int,
+                            default=50)
+search_command.add_argument('--snippets',
+                            '-S',
+                            help='Include snippets.',
+                            action='store_true')
+search_command.add_argument('--decorate',
+                            '-D',
+                            help='Decorate snippets with syntactic hints',
+                            action='store_true')
+search_command.add_argument('--context',
+                            '-U',
+                            help='Lines of context to inclued in snippets.',
+                            type=int,
+                            default=3)
+search_command.set_defaults(func=lambda cs, a: cs.SendRequestToServer(
+    CompoundRequest(search_request=[
+        SearchRequest(query=a.query,
+                      return_snippets=(a.snippets or a.decorate),
+                      return_decorated_snippets=a.decorate,
+                      max_num_results=a.max_results,
+                      lines_context=a.context)
+    ])))
 
 # status
-status_command = subcommands.add_parser(
-    'status', help='CodeSearch server status', parents=[common_args])
-status_command.set_defaults(
-    func=
-    lambda cs, a: cs.SendRequestToServer(CompoundRequest(status_request=[{}])))
+status_command = subcommands.add_parser('status',
+                                        help='CodeSearch server status',
+                                        parents=[common_args])
+status_command.set_defaults(func=lambda cs, a: cs.SendRequestToServer(
+    CompoundRequest(status_request=[{}])))
 
 arguments = parser.parse_args()
 codesearch_instance = None
 
 try:
-  codesearch_instance = CodeSearch(
-      source_root='/' if arguments.root else None,
-      a_path_inside_source_dir=os.getcwd(),
-      cache_dir=arguments.cache if arguments.cache else None)
-  setup_logging(codesearch_instance, arguments)
-  result = arguments.func(codesearch_instance, arguments)
-  print_result(result, arguments)
+    codesearch_instance = CodeSearch(
+        source_root='/' if arguments.root else None,
+        a_path_inside_source_dir=os.getcwd(),
+        cache_dir=arguments.cache if arguments.cache else None)
+    setup_logging(codesearch_instance, arguments)
+    result = arguments.func(codesearch_instance, arguments)
+    print_result(result, arguments)
 except Exception as e:
-  print(e)
+    print(e)
 finally:
-  if codesearch_instance is not None:
-    codesearch_instance.TeardownCache()
+    if codesearch_instance is not None:
+        codesearch_instance.TeardownCache()

--- a/codesearch/client_api.py
+++ b/codesearch/client_api.py
@@ -15,144 +15,147 @@ import sys
 
 from .file_cache import FileCache
 from .messages import \
-        Annotation, \
-        AnnotationRequest, \
-        AnnotationType, \
-        AnnotationTypeValue, \
-        CallGraphRequest, \
-        CallGraphResponse, \
-        CodeBlock, \
-        CodeBlockType, \
-        CompoundRequest, \
-        CompoundResponse, \
-        EdgeEnumKind, \
-        FileInfo, \
-        FileInfoRequest, \
-        FileSpec, \
-        GobInfo, \
-        KytheNodeKind, \
-        KytheXrefKind, \
-        Node, \
-        NodeEnumKind, \
-        SearchRequest, \
-        SearchResult, \
-        TextRange, \
-        XrefSearchRequest, \
-        XrefSearchResult, \
-        XrefSingleMatch
+    Annotation, \
+    AnnotationRequest, \
+    AnnotationType, \
+    AnnotationTypeValue, \
+    CallGraphRequest, \
+    CodeBlock, \
+    CodeBlockType, \
+    CompoundRequest, \
+    CompoundResponse, \
+    FileInfo, \
+    FileInfoRequest, \
+    FileSpec, \
+    KytheNodeKind, \
+    KytheXrefKind, \
+    Node, \
+    NodeEnumKind, \
+    SearchRequest, \
+    SearchResult, \
+    TextRange, \
+    XrefSearchRequest, \
+    XrefSearchResult, \
+    XrefSingleMatch
 from .paths import GetSourceRoot
 from .compat import StringFromBytes
-from .language_utils import SymbolSuffixMatcher, IsIdentifier
+from .language_utils import SymbolSuffixMatcher
 
 if sys.version_info >= (3, 0):
-  from urllib.request import urlopen, Request
-  from urllib.parse import urlencode, urlparse, unquote
+    from urllib.request import urlopen, Request
+    from urllib.parse import urlencode, urlparse, unquote
 else:
-  from urllib2 import urlopen, Request
-  from urllib import urlencode
-  from urlparse import urlparse, unquote
+    from urllib2 import urlopen, Request
+    from urllib import urlencode
+    from urlparse import urlparse, unquote
 
 # For type checking. Not needed at runtime.
 try:
-  from typing import List, Optional, Dict, Union, Set
+    from typing import List, Optional, Dict, Union, Set
 except ImportError:
-  pass
+    pass
 
 
 class ServerError(Exception):
-  """An error that occurred when talking to the CodeSearch backend."""
-  pass
+    """An error that occurred when talking to the CodeSearch backend."""
+    pass
 
 
 class NoFileSpecError(Exception):
-  """XrefNode object didn't have an associated FileSpec.
+    """XrefNode object didn't have an associated FileSpec.
 
   A valid FileSpec is required for traversing node relationships.
   """
-  pass
+    pass
 
 
 class NotFoundError(Exception):
-  """Something you were looking for was not found."""
-  pass
+    """Something you were looking for was not found."""
+    pass
 
 
 class CsFile(object):
-  """Represents a source file known to CodeSearch and allows looking up annotations."""
+    """Represents a source file known to CodeSearch."""
 
-  def __init__(self, cs, file_info):
-    # type: (CodeSearch, FileInfo) -> None
-    assert isinstance(cs, CodeSearch)
-    assert isinstance(file_info, FileInfo)
+    def __init__(self, cs, file_info):
+        # type: (CodeSearch, FileInfo) -> None
+        assert isinstance(cs, CodeSearch)
+        assert isinstance(file_info, FileInfo)
 
-    self.cs = cs  # type: CodeSearch
-    self.file_info = file_info  # type: FileInfo
-    self.lines = self.file_info.content.text.splitlines()  # type: List[str]
+        self.cs = cs  # type: CodeSearch
+        self.file_info = file_info  # type: FileInfo
+        self.lines = self.file_info.content.text.splitlines()  # type: List[str]
 
-    codeblocks = self.file_info.codeblock
-    assert isinstance(codeblocks, list)
-    assert len(codeblocks) == 0 or isinstance(codeblocks[0], CodeBlock)
-    self.codeblock = CodeBlock.Make(
-        child=codeblocks, type=CodeBlockType.ROOT, name="")  # type: CodeBlock
-    self.annotations = None  # type: Optional[List[Annotation]]
+        codeblocks = self.file_info.codeblock
+        assert isinstance(codeblocks, list)
+        assert len(codeblocks) == 0 or isinstance(codeblocks[0], CodeBlock)
+        self.codeblock = CodeBlock.Make(child=codeblocks,
+                                        type=CodeBlockType.ROOT,
+                                        name="")  # type: CodeBlock
+        self.annotations = None  # type: Optional[List[Annotation]]
 
-  def Path(self):
-    # type: () -> str
-    """Return the path to the file relative to the root of the source directory."""
-    return self.file_info.name
+    def Path(self):
+        # type: () -> str
+        """Return the path to the file relative to the source directory."""
+        return self.file_info.name
 
-  def Text(self, text_range):
-    # type: (TextRange) -> str
-    """Given a TextRange, returns the text corresponding to said range in this file.
+    def Text(self, text_range):
+        # type: (TextRange) -> str
+        """Given a TextRange, returns the corresponding text in this file.
 
     Any intervening newlines will be represented with a single '\n'."""
 
-    assert isinstance(text_range, TextRange)
+        assert isinstance(text_range, TextRange)
 
-    if len(self.lines) == 0:
-      raise IndexError('no text received for file contents. path:{}'.format(
-          self.file_info.name))
+        if len(self.lines) == 0:
+            raise IndexError(
+                'no text received for file contents. path:{}'.format(
+                    self.file_info.name))
 
-    if text_range.start_line <= 0 or text_range.start_line > len(self.lines) or \
-            text_range.end_line <= 0 or text_range.end_line > len(self.lines) or \
-            text_range.start_line > text_range.end_line:
-      raise IndexError(
-          'invalid range specified: ({},{}) - ({},{}) : {} lines'.format(
-              text_range.start_line, text_range.start_column,
-              text_range.end_line, text_range.end_column, len(self.lines)))
-    if text_range.start_line == text_range.end_line:
-      return self.lines[text_range.start_line - 1][text_range.start_column -
-                                                   1:text_range.end_column]
+        if text_range.start_line <= 0 \
+            or text_range.start_line > len(self.lines) \
+            or text_range.end_line <= 0 \
+            or text_range.end_line > len(self.lines) \
+            or text_range.start_line > text_range.end_line:  # noqa: E125
+            raise IndexError(
+                'invalid range specified: ({},{}) - ({},{}) : {} lines'.format(
+                    text_range.start_line, text_range.start_column,
+                    text_range.end_line, text_range.end_column,
+                    len(self.lines)))
+        if text_range.start_line == text_range.end_line:
+            return self.lines[text_range.start_line -
+                              1][text_range.start_column -
+                                 1:text_range.end_column]
 
-    first = [
-        self.lines[text_range.start_line - 1][text_range.start_column - 1:]
-    ]
-    middle = self.lines[text_range.start_line:text_range.end_line - 1]
-    end = [self.lines[text_range.end_line - 1][:text_range.end_column]]
+        first = [
+            self.lines[text_range.start_line - 1][text_range.start_column - 1:]
+        ]
+        middle = self.lines[text_range.start_line:text_range.end_line - 1]
+        end = [self.lines[text_range.end_line - 1][:text_range.end_column]]
 
-    return '\n'.join(first + middle + end)
+        return '\n'.join(first + middle + end)
 
-  def GetCodeBlock(self):
-    # type: () -> CodeBlock
-    """Retrieves a CodeBlocks of type ROOT for the file or None if one is not found.
+    def GetCodeBlock(self):
+        # type: () -> CodeBlock
+        """Retrieves a CodeBlocks of type ROOT for the file or None if one is not found.
 
     Note that a CodeBlock list is only preset if one is requested explicitly at
     the time the FileInfo request was made by setting the ``fetch_outline```
     field to True.
     """
-    return self.codeblock
+        return self.codeblock
 
-  def FindCodeBlock(self, name="", type=CodeBlockType.ROOT):
-    # type: (str, int) -> Optional[CodeBlock]
-    """Find a codeblock in this file that matches the name and type. If there
+    def FindCodeBlock(self, name="", type=CodeBlockType.ROOT):
+        # type: (str, int) -> Optional[CodeBlock]
+        """Find a codeblock in this file that matches the name and type. If there
     are more than one, could return any."""
-    if self.codeblock is None:
-      return None
-    return self.codeblock.Find(name, type)
+        if self.codeblock is None:
+            return None
+        return self.codeblock.Find(name, type)
 
-  def GetSignatureForCodeBlock(self, codeblock):
-    # type: (CodeBlock) -> Optional[str]
-    """Return a signature for a CodeBlock or None if no signature could be determined.
+    def GetSignatureForCodeBlock(self, codeblock):
+        # type: (CodeBlock) -> Optional[str]
+        """Return a signature for a CodeBlock or None on failure.
 
     The ``signature`` field included included in the CodeBlock is the function
     signature for a FUNCTION type CodeBlock and not the CodeSearch signature.
@@ -164,74 +167,73 @@ class CsFile(object):
     If one is found and if that annotation has a signature, then that signature
     is returned.
     """
-    assert isinstance(codeblock, CodeBlock)
+        assert isinstance(codeblock, CodeBlock)
 
-    # Can't do much with this codeblock if it doesn't have a range or a name.
-    # This is the case for a root CodeBlock, but we are generalizing it to
-    # include any CodeBlock without a name or a range. It's not considered an
-    # error since we expect this to be the case for some code blocks that don't
-    # map to a signature.
-    if not codeblock.name:
-      return None
+        # Can't do much with this codeblock if it doesn't have a range or a
+        # name.  This is the case for a root CodeBlock, but we are generalizing
+        # it to include any CodeBlock without a name or a range. It's not
+        # considered an error since we expect this to be the case for some code
+        # blocks that don't map to a signature.
+        if not codeblock.name:
+            return None
 
-    assert isinstance(codeblock.text_range, TextRange)
+        assert isinstance(codeblock.text_range, TextRange)
 
-    annotations = self.GetAnnotations()
+        annotations = self.GetAnnotations()
 
-    for annotation in annotations:
-      if not annotation.HasSignature():
-        continue
-      if not codeblock.text_range.Overlaps(annotation.range):
-        continue
-      if self.Text(annotation.range) == codeblock.name:
-        return annotation.GetSignature()
-    return None
+        for annotation in annotations:
+            if not annotation.HasSignature():
+                continue
+            if not codeblock.text_range.Overlaps(annotation.range):
+                continue
+            if self.Text(annotation.range) == codeblock.name:
+                return annotation.GetSignature()
+        return None
 
-  def GetFileSpec(self):
-    # type: () -> FileSpec
-    if self.file_info.gob_info.commit:
-      return FileSpec(
-          name=self.file_info.name,
-          package_name=self.file_info.package_name,
-          changelist=self.file_info.gob_info.commit)
+    def GetFileSpec(self):
+        # type: () -> FileSpec
+        if self.file_info.gob_info.commit:
+            return FileSpec(name=self.file_info.name,
+                            package_name=self.file_info.package_name,
+                            changelist=self.file_info.gob_info.commit)
 
-    return FileSpec(
-        name=self.file_info.name, package_name=self.file_info.package_name)
+        return FileSpec(name=self.file_info.name,
+                        package_name=self.file_info.package_name)
 
-  def GetAnnotations(self):
-    # type: () -> List[Annotation]
-    if self.annotations is None:
-      response = self.cs.GetAnnotationsForFile(
-          self.GetFileSpec(), md5=self.file_info.md5)
-      if response.annotation_response is None or len(
-          response.annotation_response) != 1:
-        return []
-      self.annotations = response.annotation_response[0].annotation
-      assert isinstance(self.annotations, list)
-      assert isinstance(self.annotations[0], Annotation)
+    def GetAnnotations(self):
+        # type: () -> List[Annotation]
+        if self.annotations is None:
+            response = self.cs.GetAnnotationsForFile(self.GetFileSpec(),
+                                                     md5=self.file_info.md5)
+            if response.annotation_response is None or \
+                len(response.annotation_response) != 1:  # noqa
+                return []
+            self.annotations = response.annotation_response[0].annotation
+            assert isinstance(self.annotations, list)
+            assert isinstance(self.annotations[0], Annotation)
 
-    if self.annotations is None:
-      return []
-    return self.annotations
+        if self.annotations is None:
+            return []
+        return self.annotations
 
-  def GetAnchorText(self, signature):
-    # type: (str) -> str
+    def GetAnchorText(self, signature):
+        # type: (str) -> str
 
-    self.GetAnnotations()
-    assert isinstance(self.annotations, list)
-    assert len(self.annotations) == 0 or isinstance(self.annotations[0],
-                                                    Annotation)
+        self.GetAnnotations()
+        assert isinstance(self.annotations, list)
+        assert len(self.annotations) == 0 or isinstance(self.annotations[0],
+                                                        Annotation)
 
-    for annotation in self.annotations:
-      if annotation.MatchesSignature(signature):
-        return self.Text(annotation.range)
+        for annotation in self.annotations:
+            if annotation.MatchesSignature(signature):
+                return self.Text(annotation.range)
 
-    raise NotFoundError(
-        'can\'t determine display name for {}'.format(signature))
+        raise NotFoundError(
+            'can\'t determine display name for {}'.format(signature))
 
 
 class XrefNode(object):
-  """A cross-reference node.
+    """A cross-reference node.
 
   The codesearch data is represented as a graph of nodes where locations in
   source or symbols are are connected to other symbols or locations in source
@@ -255,7 +257,8 @@ class XrefNode(object):
   >>> cs = codesearch.CodeSearch(source_root='.')
 
   # Ditto for the path to source:
-  >>> sig = cs.GetSignatureForSymbol('src/net/http/http_network_transaction.cc', 'HttpNetworkTransaction')
+  >>> sig = cs.GetSignatureForSymbol(
+      'src/net/http/http_network_transaction.cc', 'HttpNetworkTransaction')
   >>> node = codesearch.XrefNode.FromSignature(cs, sig)
   >>> node.Traverse(codesearch.KytheXrefKind.REFERENCE)
 
@@ -268,9 +271,9 @@ class XrefNode(object):
   and |single_match| members other than the signature.
   """
 
-  def __init__(self, cs, single_match, filespec=None, parent=None):
-    # type: (CodeSearch, XrefSingleMatch, Optional[FileSpec], Optional[XrefNode]) -> None
-    """Constructs an XrefNode.
+    def __init__(self, cs, single_match, filespec=None, parent=None):
+        # type: (CodeSearch, XrefSingleMatch, Optional[FileSpec], Optional[XrefNode]) -> None  # noqa: E501
+        """Constructs an XrefNode.
 
     This is probably not what you are looking for. Instead figure out the
     signature of the node you want to start with using one of the
@@ -280,19 +283,19 @@ class XrefNode(object):
     From there, you can use the GetEdge() and/or GetAllEdges() methods to
     explore the cross references."""
 
-    self.cs = cs
-    self.filespec = filespec
-    self.single_match = single_match
-    self.parent = parent
+        self.cs = cs
+        self.filespec = filespec
+        self.single_match = single_match
+        self.parent = parent
 
-    assert isinstance(self.cs, CodeSearch)
-    assert isinstance(self.single_match, XrefSingleMatch)
-    assert self.filespec is None or isinstance(self.filespec, FileSpec)
-    assert self.parent is None or isinstance(self.parent, XrefNode)
+        assert isinstance(self.cs, CodeSearch)
+        assert isinstance(self.single_match, XrefSingleMatch)
+        assert self.filespec is None or isinstance(self.filespec, FileSpec)
+        assert self.parent is None or isinstance(self.parent, XrefNode)
 
-  def Traverse(self, xref_kinds=None, max_num_results=500):
-    # type: (Union[int,List[int]], int) -> List[XrefNode]
-    """Gets outgoing edges for this node.
+    def Traverse(self, xref_kinds=None, max_num_results=500):
+        # type: (Union[int,List[int]], int) -> List[XrefNode]
+        """Gets outgoing edges for this node.
 
     Returns a list of XrefNode objects. If there are no results, then returns
     an empty list.
@@ -302,125 +305,128 @@ class XrefNode(object):
     to return.
     """
 
-    s_results = self.cs.GetXrefsFor(self.single_match.signature,
-                                    max_num_results)
-    if not s_results:
-      return []
+        s_results = self.cs.GetXrefsFor(self.single_match.signature,
+                                        max_num_results)
+        if not s_results:
+            return []
 
-    results = XrefNode.FromSearchResults(self.cs, s_results, self)
-    if xref_kinds is None:
-      return results
+        results = XrefNode.FromSearchResults(self.cs, s_results, self)
+        if xref_kinds is None:
+            return results
 
-    if isinstance(xref_kinds, list):
-      xrset = set(xref_kinds)
-    else:
-      xrset = set()
-      xrset.add(xref_kinds)
+        if isinstance(xref_kinds, list):
+            xrset = set(xref_kinds)
+        else:
+            xrset = set()
+            xrset.add(xref_kinds)
 
-    # Make sure that the incoming filter is based on KytheXrefKind and not the
-    # deprecated NodeEnumKind. Fortunately, the valid numbers for each type are
-    # disjoint.
-    for v in xrset:
-      assert KytheXrefKind.ToSymbol(v) != v
+        # Make sure that the incoming filter is based on KytheXrefKind and not
+        # the deprecated NodeEnumKind. Fortunately, the valid numbers for each
+        # type are disjoint.
+        for v in xrset:
+            assert KytheXrefKind.ToSymbol(v) != v
 
-    cg = []
-    if KytheXrefKind.CALLED_BY in xrset:
-      cg.extend([
-          XrefNode.FromNode(self.cs, n)
-          for n in self._GetCallGraphNode(max_num_results).children
-      ])
+        cg = []
+        if KytheXrefKind.CALLED_BY in xrset:
+            cg.extend([
+                XrefNode.FromNode(self.cs, n)
+                for n in self._GetCallGraphNode(max_num_results).children
+            ])
 
-    return list(filter(lambda n: n.single_match.type_id in xrset, results)) + cg
+        return list(filter(lambda n: n.single_match.type_id in xrset,
+                           results)) + cg
 
-  def _GetCallGraphNode(self, max_num_results=500):
-    # type: (int) -> Node
-    """Returns a single Node containing one level of the incoming call graph."""
+    def _GetCallGraphNode(self, max_num_results=500):
+        # type: (int) -> Node
+        """Returns a Node containing one level of the incoming call graph."""
 
-    cg_response = self.cs.GetCallGraph(
-        signature=self.single_match.signature, max_num_results=max_num_results)
+        cg_response = self.cs.GetCallGraph(
+            signature=self.single_match.signature,
+            max_num_results=max_num_results)
 
-    if not cg_response or not cg_response.call_graph_response:
-      raise ServerError("Unexpected response. {}".format(cg_response))
+        if not cg_response or not cg_response.call_graph_response:
+            raise ServerError("Unexpected response. {}".format(cg_response))
 
-    response = cg_response.call_graph_response[0]
+        response = cg_response.call_graph_response[0]
 
-    if not response.node.children:
-      raise NotFoundError("No callers for signature {} ({})".format(
-          self.single_match.signature, self.GetDisplayName()))
+        if not response.node.children:
+            raise NotFoundError("No callers for signature {} ({})".format(
+                self.single_match.signature, self.GetDisplayName()))
 
-    return response.node
+        return response.node
 
-  def GetFile(self):
-    # type: () -> CsFile
-    """Return the file containing this XrefNode as a CsFile."""
-    if not self.filespec:
-      raise NoFileSpecError('no filespec found for XrefNode')
-    return self.cs.GetFileInfo(self.filespec)
+    def GetFile(self):
+        # type: () -> CsFile
+        """Return the file containing this XrefNode as a CsFile."""
+        if not self.filespec:
+            raise NoFileSpecError('no filespec found for XrefNode')
+        return self.cs.GetFileInfo(self.filespec)
 
-  def GetDisplayName(self, try_via_references=True):
-    """Return the display name for this XrefNode.
+    def GetDisplayName(self, try_via_references=True):
+        """Return the display name for this XrefNode.
 
     It is possible for there to be no associated displayname. E.g. if the
     XrefNode corresponds to a template specialization. In that case, this
     method will throw.
     """
 
-    if not self.filespec:
-      raise NoFileSpecError('no filespec found for XrefNode')
+        if not self.filespec:
+            raise NoFileSpecError('no filespec found for XrefNode')
 
-    try:
-      return self.cs.GetFileInfo(self.filespec).GetAnchorText(
-          self.single_match.signature)
-    except ServerError as e:
-      # Backend index is incomplete :-(. Unfortunately, this happens often,
-      # and is generally expected when following links to STL symbols.
-      if 'Could not resolve' in e.message and try_via_references:
-        pass
-      raise e
+        try:
+            return self.cs.GetFileInfo(self.filespec).GetAnchorText(
+                self.single_match.signature)
+        except ServerError as e:
+            # Backend index is incomplete :-(. Unfortunately, this happens
+            # often, and is generally expected when following links to STL
+            # symbols.
+            if 'Could not resolve' in e.message and try_via_references:
+                pass
+            raise e
 
-    # Backup logic. Try to lookup a reference that works. Only try 5 times.
-    for ref in self.Traverse(KytheXrefKind.REFERENCE)[:5]:
-      try:
-        # Setting try_via_references to False since we don't want to fan
-        # out a tree of retries. Something should work at this level or we
-        # should just give up instead of DoSing the server.
-        return ref.GetDisplayName(try_via_references=False)
-      except ServerError as e:
-        pass
-    raise NotFoundError('display name could not be resolved for {}'.format(
-        self.single_match.signature))
+        # Backup logic. Try to lookup a reference that works. Only try 5 times.
+        for ref in self.Traverse(KytheXrefKind.REFERENCE)[:5]:
+            try:
+                # Setting try_via_references to False since we don't want to fan
+                # out a tree of retries. Something should work at this level or
+                # we should just give up instead of DoSing the server.
+                return ref.GetDisplayName(try_via_references=False)
+            except ServerError:
+                pass
+        raise NotFoundError('display name could not be resolved for {}'.format(
+            self.single_match.signature))
 
-  def GetRelatedAnnotations(self):
-    # type: () -> List[Annotation]
-    """Get related annotations. Currently this is defined to be annotations
+    def GetRelatedAnnotations(self):
+        # type: () -> List[Annotation]
+        """Get related annotations. Currently this is defined to be annotations
     that surround the current xref location."""
 
-    if not self.filespec:
-      raise NoFileSpecError('no filespec found for XrefNode')
+        if not self.filespec:
+            raise NoFileSpecError('no filespec found for XrefNode')
 
-    annotations = self.cs.GetFileInfo(self.filespec).GetAnnotations()
-    target_range = None
-    for annotation in annotations:
-      if annotation.MatchesSignature(self.single_match.signature):
-        target_range = annotation.range
-        break
+        annotations = self.cs.GetFileInfo(self.filespec).GetAnnotations()
+        target_range = None
+        for annotation in annotations:
+            if annotation.MatchesSignature(self.single_match.signature):
+                target_range = annotation.range
+                break
 
-    if not target_range:
-      raise NotFoundError('no related annotations')
+        if not target_range:
+            raise NotFoundError('no related annotations')
 
-    related = []
-    for annotation in annotations:
-      if annotation.range.end_line < target_range.start_line or \
-              annotation.range.start_line > target_range.end_line:
-        continue
-      if annotation.range == target_range:
-        continue
-      related.append(annotation)
-    return related
+        related = []
+        for annotation in annotations:
+            if annotation.range.end_line < target_range.start_line or \
+                    annotation.range.start_line > target_range.end_line:
+                continue
+            if annotation.range == target_range:
+                continue
+            related.append(annotation)
+        return related
 
-  def GetRelatedDefinitions(self):
-    # type: () -> List[XrefNode]
-    """Get related definitions. Currently this is defined to be linked
+    def GetRelatedDefinitions(self):
+        # type: () -> List[XrefNode]
+        """Get related definitions. Currently this is defined to be linked
     definitions that surround the current xref location.
 
     This is a hack that can be used to get at the type of a class member. E.g.:
@@ -443,168 +449,168 @@ class XrefNode(object):
     the type.
     """
 
-    if not self.filespec:
-      raise NoFileSpecError('no filespec found for XrefNode')
-    annotations = self.cs.GetFileInfo(self.filespec).GetAnnotations()
-    target_range = None
-    for annotation in annotations:
-      sig = annotation.xref_signature.signature
-      if sig == self.single_match.signature:
-        target_range = annotation.range
-        break
+        if not self.filespec:
+            raise NoFileSpecError('no filespec found for XrefNode')
+        annotations = self.cs.GetFileInfo(self.filespec).GetAnnotations()
+        target_range = None
+        for annotation in annotations:
+            sig = annotation.xref_signature.signature
+            if sig == self.single_match.signature:
+                target_range = annotation.range
+                break
 
-    if not target_range:
-      raise NotFoundError('no related annotations')
+        if not target_range:
+            raise NotFoundError('no related annotations')
 
-    related = []
-    for annotation in annotations:
-      if annotation.type.id != AnnotationTypeValue.LINK_TO_DEFINITION:
-        continue
-      if annotation.range.end_line < target_range.start_line or \
-              annotation.range.start_line > target_range.end_line:
-        continue
+        related = []
+        for annotation in annotations:
+            if annotation.type.id != AnnotationTypeValue.LINK_TO_DEFINITION:
+                continue
+            if annotation.range.end_line < target_range.start_line or \
+                    annotation.range.start_line > target_range.end_line:
+                continue
 
-      abstract_node = XrefNode.FromAnnotation(self.cs, annotation)
-      def_list = abstract_node.Traverse(KytheXrefKind.DEFINITION)
-      if def_list:
-        related.append(def_list[0])
-        continue
+            abstract_node = XrefNode.FromAnnotation(self.cs, annotation)
+            def_list = abstract_node.Traverse(KytheXrefKind.DEFINITION)
+            if def_list:
+                related.append(def_list[0])
+                continue
 
-      dcl_list = abstract_node.Traverse(KytheXrefKind.DECLARATION)
-      if dcl_list:
-        related.append(dcl_list[0])
-        continue
+            dcl_list = abstract_node.Traverse(KytheXrefKind.DECLARATION)
+            if dcl_list:
+                related.append(dcl_list[0])
+                continue
 
-      related.append(abstract_node)
-    return related
+            related.append(abstract_node)
+        return related
 
-  def GetSignature(self):
-    # type: () -> str
-    """Return the signature for this node"""
-    return self.single_match.signature.split(' ')[0]
+    def GetSignature(self):
+        # type: () -> str
+        """Return the signature for this node"""
+        return self.single_match.signature.split(' ')[0]
 
-  def GetSignatures(self):
-    # type: () -> List[str]
-    return self.single_match.signature.split(' ')
+    def GetSignatures(self):
+        # type: () -> List[str]
+        return self.single_match.signature.split(' ')
 
-  def __str__(self):
-    s = "{"
-    if self.filespec:
-      s += "filespec: {}, ".format(str(self.filespec))
-    s += "single_match: {}".format(str(self.single_match))
-    s += "}"
-    return s
+    def __str__(self):
+        s = "{"
+        if self.filespec:
+            s += "filespec: {}, ".format(str(self.filespec))
+        s += "single_match: {}".format(str(self.single_match))
+        s += "}"
+        return s
 
-  @staticmethod
-  def FromSignature(cs, signature, filename=None):
-    # type: (CodeSearch, str, Union[None, str, FileSpec]) -> XrefNode
-    """Construct a XrefNode object for |signature|.
+    @staticmethod
+    def FromSignature(cs, signature, filename=None):
+        # type: (CodeSearch, str, Union[None, str, FileSpec]) -> XrefNode
+        """Construct a XrefNode object for |signature|.
 
     Other than the |signature| the constructured node will have no other
     interesting fields. It can, however, be used to query outgoing edges.
     """
 
-    assert isinstance(cs, CodeSearch)
-    assert signature
+        assert isinstance(cs, CodeSearch)
+        assert signature
 
-    if filename is None:
-      filespec = cs.GetFileSpecFromSignature(signature)
-    else:
-      filespec = cs.GetFileSpec(filename)
+        if filename is None:
+            filespec = cs.GetFileSpecFromSignature(signature)
+        else:
+            filespec = cs.GetFileSpec(filename)
 
-    return XrefNode(
-        cs,
-        filespec=filespec,
-        single_match=XrefSingleMatch(signature=signature))
+        return XrefNode(cs,
+                        filespec=filespec,
+                        single_match=XrefSingleMatch(signature=signature))
 
-  @staticmethod
-  def FromNode(cs, node):
-    # type: (CodeSearch, Node) -> XrefNode
-    """Construct a XrefNode based on a Node.
+    @staticmethod
+    def FromNode(cs, node):
+        # type: (CodeSearch, Node) -> XrefNode
+        """Construct a XrefNode based on a Node.
     """
 
-    assert isinstance(cs, CodeSearch)
-    assert isinstance(node, Node)
+        assert isinstance(cs, CodeSearch)
+        assert isinstance(node, Node)
 
-    line_text = ""
-    line_number = node.call_site_range.start_line
+        line_text = ""
+        line_number = node.call_site_range.start_line
 
-    # Snippets for Node results only contain one line of text.
-    if node.snippet.text.text:
-      line_text = node.snippet.text.text
-      line_number = node.snippet.first_line_number
+        # Snippets for Node results only contain one line of text.
+        if node.snippet.text.text:
+            line_text = node.snippet.text.text
+            line_number = node.snippet.first_line_number
 
-    match = XrefSingleMatch(
-        line_number=line_number, line_text=line_text, signature=node.signature)
-    return XrefNode(
-        cs=cs,
-        single_match=match,
-        filespec=FileSpec(name=node.file_path, package_name=node.package_name))
+        match = XrefSingleMatch(line_number=line_number,
+                                line_text=line_text,
+                                signature=node.signature)
+        return XrefNode(cs=cs,
+                        single_match=match,
+                        filespec=FileSpec(name=node.file_path,
+                                          package_name=node.package_name))
 
-  @staticmethod
-  def FromAnnotation(cs, annotation):
-    # type: (CodeSearch, Annotation) -> XrefNode
-    """Construct a XrefNode based on an Annotation.
+    @staticmethod
+    def FromAnnotation(cs, annotation):
+        # type: (CodeSearch, Annotation) -> XrefNode
+        """Construct a XrefNode based on an Annotation.
 
     This is currently limited to annotations that have a LINK_TO_DEFINITION."""
 
-    assert isinstance(annotation, Annotation)
-    assert annotation.type.id == AnnotationTypeValue.LINK_TO_DEFINITION
+        assert isinstance(annotation, Annotation)
+        assert annotation.type.id == AnnotationTypeValue.LINK_TO_DEFINITION
 
-    return XrefNode.FromSignature(
-        cs,
-        annotation.internal_link.signature,
-        filename=FileSpec(
-            name=annotation.internal_link.path,
-            package_name=annotation.internal_link.package_name))
+        return XrefNode.FromSignature(
+            cs,
+            annotation.internal_link.signature,
+            filename=FileSpec(
+                name=annotation.internal_link.path,
+                package_name=annotation.internal_link.package_name))
 
-  @staticmethod
-  def FromSearchResults(cs, results, parent=None):
-    # type: (CodeSearch, List[XrefSearchResult], Optional[XrefNode]) -> List[XrefNode]
-    """Construct a *list* of XrefNode objects from a list of XrefSearchResult
+    @staticmethod
+    def FromSearchResults(cs, results, parent=None):
+        # type: (CodeSearch, List[XrefSearchResult], Optional[XrefNode]) -> List[XrefNode] # noqa: E501
+        """Construct a *list* of XrefNode objects from a list of XrefSearchResult
     objects.
     """
-    nodes = []
+        nodes = []
 
-    assert isinstance(cs, CodeSearch)
-    assert isinstance(results, list)
+        assert isinstance(cs, CodeSearch)
+        assert isinstance(results, list)
 
-    for result in results:
-      assert isinstance(result, XrefSearchResult)
+        for result in results:
+            assert isinstance(result, XrefSearchResult)
 
-      for match in result.match:
-        assert isinstance(match, XrefSingleMatch)
+            for match in result.match:
+                assert isinstance(match, XrefSingleMatch)
 
-        nodes.append(XrefNode(cs, match, result.file, parent))
+                nodes.append(XrefNode(cs, match, result.file, parent))
 
-    return nodes
+        return nodes
 
 
 class CodeSearch(object):
+    class Stats(object):
+        """Used internally to track how many requests are being made."""
 
-  class Stats(object):
-    """Used internally to track how many requests are being made."""
+        def __init__(self):
+            self.cache_hits = 0  # type: int
 
-    def __init__(self):
-      self.cache_hits = 0  # type: int
+            # cache_misses is also the number of network requests made.
+            self.cache_misses = 0  # type: int
 
-      # cache_misses is also the number of network requests made.
-      self.cache_misses = 0  # type: int
-
-  def __init__(
-      self,
-      should_cache=False,  # type: bool
-      cache_dir=None,  # type: Optional[str]
-      cache_timeout_in_seconds=1800,  # type: int
-      source_root=None,  # type: Optional[str]
-      a_path_inside_source_dir=None,  # type: Optional[str]
-      package_name='chromium',  # type: str
-      codesearch_host='https://cs.chromium.org',  # type: str
-      request_timeout_in_seconds=10,  # type: int
-      user_agent_string='Python-CodeSearch-Client (https://github.com/chromium/codesearch-py)'  # type: str
-  ):
-    # type: (...) -> None
-    """Initialize a CodeSearch object.
+    def __init__(
+            self,
+            should_cache=False,  # type: bool
+            cache_dir=None,  # type: Optional[str]
+            cache_timeout_in_seconds=1800,  # type: int
+            source_root=None,  # type: Optional[str]
+            a_path_inside_source_dir=None,  # type: Optional[str]
+            package_name='chromium',  # type: str
+            codesearch_host='https://cs.chromium.org',  # type: str
+            request_timeout_in_seconds=10,  # type: int
+            user_agent_string='Python-CodeSearch-Client '
+            '(https://github.com/chromium/codesearch-py)'  # type: str
+    ):
+        # type: (...) -> None
+        """Initialize a CodeSearch object.
 
     Creating a CodeSearch object is probably the first thing you are going to
     do since all the other classes that make requests to the codesearch
@@ -662,86 +668,87 @@ class CodeSearch(object):
     >>> cs = CodeSearch(source_root='.')
     """
 
-    # An instance of FileCache or None if no caching is to be performed.
-    self.file_cache = None  # type: Optional[FileCache]
+        # An instance of FileCache or None if no caching is to be performed.
+        self.file_cache = None  # type: Optional[FileCache]
 
-    # A cache mapping path -> CsFile objects.
-    self.file_info_cache = {}  # type: Dict[str, CsFile]
+        # A cache mapping path -> CsFile objects.
+        self.file_info_cache = {}  # type: Dict[str, CsFile]
 
-    self.logger = logging.getLogger('codesearch')
+        self.logger = logging.getLogger('codesearch')
 
-    self.package_name = package_name
+        self.package_name = package_name
 
-    self.codesearch_host = codesearch_host
+        self.codesearch_host = codesearch_host
 
-    self.request_timeout_in_seconds = request_timeout_in_seconds
+        self.request_timeout_in_seconds = request_timeout_in_seconds
 
-    self.source_root = source_root if source_root else GetSourceRoot(
-        a_path_inside_source_dir)
+        self.source_root = source_root if source_root else GetSourceRoot(
+            a_path_inside_source_dir)
 
-    self.extra_headers = {
-        'User-Agent': user_agent_string
-    }  # type: Dict[str, str]
+        self.extra_headers = {
+            'User-Agent': user_agent_string
+        }  # type: Dict[str, str]
 
-    self.stats = CodeSearch.Stats()
+        self.stats = CodeSearch.Stats()
 
-    # Latest known GOB revision (i.e. a Git commit digest). It starts out empty,
-    # but will be populated with the latest revision we know of.
-    self.gob_revision = ''  # type: str
+        # Latest known GOB revision (i.e. a Git commit digest). It starts out
+        # empty, but will be populated with the latest revision we know of.
+        self.gob_revision = ''  # type: str
 
-    if should_cache:
-      self.file_cache = FileCache(
-          cache_dir=cache_dir, expiration_in_seconds=cache_timeout_in_seconds)
+        if should_cache:
+            self.file_cache = FileCache(
+                cache_dir=cache_dir,
+                expiration_in_seconds=cache_timeout_in_seconds)
 
-  def GetSourceRoot(self):
-    # type: () -> str
-    return self.source_root
+    def GetSourceRoot(self):
+        # type: () -> str
+        return self.source_root
 
-  def GetLogger(self):
-    # type: () -> logging.Logger
-    return self.logger
+    def GetLogger(self):
+        # type: () -> logging.Logger
+        return self.logger
 
-  def GetFileSpec(self, path=None):
-    # type: (Union[str,FileSpec,None]) -> FileSpec
-    if path is None:
-      return FileSpec(name='.', package_name=self.package_name)
+    def GetFileSpec(self, path=None):
+        # type: (Union[str,FileSpec,None]) -> FileSpec
+        if path is None:
+            return FileSpec(name='.', package_name=self.package_name)
 
-    if isinstance(path, FileSpec):
-      return path
+        if isinstance(path, FileSpec):
+            return path
 
-    relpath = os.path.relpath(os.path.abspath(path), self.source_root).replace(
-        '\\', '/')
-    return FileSpec(name=relpath, package_name=self.package_name)
+        relpath = os.path.relpath(os.path.abspath(path),
+                                  self.source_root).replace('\\', '/')
+        return FileSpec(name=relpath, package_name=self.package_name)
 
-  def GetFileSpecFromSignature(self, signature):
-    # type: (str) -> FileSpec
-    KYTHE_PREFIX = "kythe://"
-    assert signature.startswith(KYTHE_PREFIX)
-    signature = signature[len(KYTHE_PREFIX):].split('#')[0]
-    args = signature.split('?')
-    assert len(args) > 1
-    path = ""
-    for a in args:
-      if a.startswith("path="):
-        path = unquote(a[5:])
-    assert path != ""
-    return FileSpec(name=path, package_name=args[0])
+    def GetFileSpecFromSignature(self, signature):
+        # type: (str) -> FileSpec
+        KYTHE_PREFIX = "kythe://"
+        assert signature.startswith(KYTHE_PREFIX)
+        signature = signature[len(KYTHE_PREFIX):].split('#')[0]
+        args = signature.split('?')
+        assert len(args) > 1
+        path = ""
+        for a in args:
+            if a.startswith("path="):
+                path = unquote(a[5:])
+        assert path != ""
+        return FileSpec(name=path, package_name=args[0])
 
-  def GetRevision(self):
-    # type: () -> str
-    '''Retrieve the Git revision for the current search index.'''
-    return self.gob_revision
+    def GetRevision(self):
+        # type: () -> str
+        '''Retrieve the Git revision for the current search index.'''
+        return self.gob_revision
 
-  def TeardownCache(self):
-    # type: () -> None
-    if self.file_cache:
-      self.file_cache.close()
+    def TeardownCache(self):
+        # type: () -> None
+        if self.file_cache:
+            self.file_cache.close()
 
-    self.file_cache = None
+        self.file_cache = None
 
-  def _Retrieve(self, url):
-    # type: (str) -> str
-    """Retrieve the URL, optionally using the cache.
+    def _Retrieve(self, url):
+        # type: (str) -> str
+        """Retrieve the URL, optionally using the cache.
 
     If a cache is in use, checks if the URL is cached, otherwise sends it to the
     network. Note that the cache in question may not obey usual HTTP caching
@@ -750,68 +757,71 @@ class CodeSearch(object):
     The response is a str object containing the response body on success. Will
     throw on failure.
     """
-    self.logger.debug('Fetching %s', url)
+        self.logger.debug('Fetching %s', url)
 
-    if self.file_cache:
-      cached_response = self.file_cache.get(url)
-      self.logger.debug('Found cached response')
-      if (cached_response):
-        self.stats.cache_hits += 1
-        return cached_response.decode('utf8')
-    self.stats.cache_misses += 1
+        if self.file_cache:
+            cached_response = self.file_cache.get(url)
+            self.logger.debug('Found cached response')
+            if (cached_response):
+                self.stats.cache_hits += 1
+                return cached_response.decode('utf8')
+        self.stats.cache_misses += 1
 
-    # Long URLs cause the request to fail. If it's too long, snip off the query
-    # and send it as a POST body. Yes, this is how it works.
-    if len(url) > 1500:
-      parsed = urlparse(url)
-      short_url = '{}://{}{}'.format(parsed.scheme, parsed.netloc, parsed.path)
-      data = parsed.query.encode('utf-8')
-      request = Request(url=short_url, headers=self.extra_headers, data=data)
-    else:
-      request = Request(url=url, headers=self.extra_headers)
+        # Long URLs cause the request to fail. If it's too long, snip off the
+        # query and send it as a POST body. Yes, this is how it works.
+        if len(url) > 1500:
+            parsed = urlparse(url)
+            short_url = '{}://{}{}'.format(parsed.scheme, parsed.netloc,
+                                           parsed.path)
+            data = parsed.query.encode('utf-8')
+            request = Request(url=short_url,
+                              headers=self.extra_headers,
+                              data=data)
+        else:
+            request = Request(url=url, headers=self.extra_headers)
 
-    response = urlopen(request, timeout=self.request_timeout_in_seconds)
-    result = response.read()
-    response.close()
-    if self.file_cache:
-      self.file_cache.put(url, result)
-    return StringFromBytes(result)
+        response = urlopen(request, timeout=self.request_timeout_in_seconds)
+        result = response.read()
+        response.close()
+        if self.file_cache:
+            self.file_cache.put(url, result)
+        return StringFromBytes(result)
 
-  def SendRequestToServer(self, compound_request):
-    # type: (CompoundRequest) -> CompoundResponse
-    if not isinstance(compound_request, CompoundRequest):
-      raise ValueError(
-          '|compound_request| should be an instance of CompoundRequest')
+    def SendRequestToServer(self, compound_request):
+        # type: (CompoundRequest) -> CompoundResponse
+        if not isinstance(compound_request, CompoundRequest):
+            raise ValueError(
+                '|compound_request| should be an instance of CompoundRequest')
 
-    qs = urlencode(compound_request.AsQueryString(), doseq=True)
-    url = '{host}/codesearch/json?{qs}'.format(host=self.codesearch_host, qs=qs)
-    result = self._Retrieve(url)
-    return CompoundResponse.FromJsonString(result)
+        qs = urlencode(compound_request.AsQueryString(), doseq=True)
+        url = '{host}/codesearch/json?{qs}'.format(host=self.codesearch_host,
+                                                   qs=qs)
+        result = self._Retrieve(url)
+        return CompoundResponse.FromJsonString(result)
 
-  def GetCallGraph(self, signature, max_num_results=500):
-    # type: (str, int) -> CompoundResponse
-    """Retrieves a list of call graph nodes corresponding to all call sites of
+    def GetCallGraph(self, signature, max_num_results=500):
+        # type: (str, int) -> CompoundResponse
+        """Retrieves a list of call graph nodes corresponding to all call sites of
     |signature|.
     """
-    return self.SendRequestToServer(
-        CompoundRequest(call_graph_request=[
-            CallGraphRequest(
-                file_spec=self.GetFileSpec(),
-                max_num_results=max_num_results,
-                signature=signature)
-        ]))
+        return self.SendRequestToServer(
+            CompoundRequest(call_graph_request=[
+                CallGraphRequest(file_spec=self.GetFileSpec(),
+                                 max_num_results=max_num_results,
+                                 signature=signature)
+            ]))
 
-  def GetAnnotationsForFile(
-      self,
-      filename,  # type: Union[str, FileSpec]
-      annotation_types=[
-          AnnotationType(id=AnnotationTypeValue.XREF_SIGNATURE),
-          AnnotationType(id=AnnotationTypeValue.LINK_TO_DEFINITION)
-      ],  # type: List[AnnotationType]
-      md5=""  # type: str
-  ):
-    # type: (...) -> CompoundResponse
-    """Retrieves a list of annotations for a file.
+    def GetAnnotationsForFile(
+            self,
+            filename,  # type: Union[str, FileSpec]
+            annotation_types=[
+                AnnotationType(id=AnnotationTypeValue.XREF_SIGNATURE),
+                AnnotationType(id=AnnotationTypeValue.LINK_TO_DEFINITION)
+            ],  # type: List[AnnotationType]
+            md5=""  # type: str
+    ):
+        # type: (...) -> CompoundResponse
+        """Retrieves a list of annotations for a file.
 
     Note that it is much more efficient in your scripts to use
     CsFile.GetAnnotations() instead of calling this function directly. CsFile
@@ -819,137 +829,137 @@ class CodeSearch(object):
     there's only one CsFile per file. This minimizes the number of requests
     sent over the network.
     """
-    return self.SendRequestToServer(
-        CompoundRequest(annotation_request=[
-            AnnotationRequest(
-                file_spec=self.GetFileSpec(filename),
-                type=annotation_types,
-                md5=md5)
-        ]))
+        return self.SendRequestToServer(
+            CompoundRequest(annotation_request=[
+                AnnotationRequest(file_spec=self.GetFileSpec(filename),
+                                  type=annotation_types,
+                                  md5=md5)
+            ]))
 
-  def GetSignatureForLocation(self, filename, line, column):
-    # type: (str, int, int) -> str
-    """Get the signature of the symbol at a specific location in a source file.
+    def GetSignatureForLocation(self, filename, line, column):
+        # type: (str, int, int) -> str
+        """Get the signature of the symbol at a specific location in a source file.
 
     All locations are 1-based."""
 
-    annotations = self.GetFileInfo(filename).GetAnnotations()
-    for annotation in annotations:
-      if not annotation.range.Contains(line, column):
-        continue
+        annotations = self.GetFileInfo(filename).GetAnnotations()
+        for annotation in annotations:
+            if not annotation.range.Contains(line, column):
+                continue
 
-      sig = annotation.GetSignature()
-      if sig is not None:
-        return sig
+            sig = annotation.GetSignature()
+            if sig is not None:
+                return sig
 
-    raise NotFoundError(
-        "can't determine signature for %s at %d:%d" % (filename, line, column))
+        raise NotFoundError("can't determine signature for %s at %d:%d" %
+                            (filename, line, column))
 
-  def _PurgeCaches(self):
-    self.file_info_cache = {}
-    if self.file_cache is not None:
-      self.file_cache.gc(purge=True)
+    def _PurgeCaches(self):
+        self.file_info_cache = {}
+        if self.file_cache is not None:
+            self.file_cache.gc(purge=True)
 
-  def _RefreshGobRevision(self):
-    i = self.GetFileInfo(
-        FileSpec(name='src/README.md', package_name=self.package_name))
-    self._RefreshGobRevisionFromFileInfo(i)
+    def _RefreshGobRevision(self):
+        i = self.GetFileInfo(
+            FileSpec(name='src/README.md', package_name=self.package_name))
+        self._RefreshGobRevisionFromFileInfo(i)
 
-  def _RefreshGobRevisionFromFileInfo(self, file_info):
-    # type: (FileInfo) -> None
-    assert isinstance(file_info, FileInfo)
+    def _RefreshGobRevisionFromFileInfo(self, file_info):
+        # type: (FileInfo) -> None
+        assert isinstance(file_info, FileInfo)
 
-    if not file_info.gob_info.commit:
-      raise ServerError(
-          'FileInfo response doesn\'t specify Git-on-Borg revision')
+        if not file_info.gob_info.commit:
+            raise ServerError(
+                'FileInfo response doesn\'t specify Git-on-Borg revision')
 
-    # We only track the revision for the root Chromium repo.
-    if file_info.gob_info.repo != 'chromium/chromium/src':
-      return
+        # We only track the revision for the root Chromium repo.
+        if file_info.gob_info.repo != 'chromium/chromium/src':
+            return
 
-    if self.gob_revision != '' and self.gob_revision != file_info.gob_info.commit:
-      self._PurgeCaches()
-    self.gob_revision = file_info.gob_info.commit
+        if self.gob_revision != '' and \
+            self.gob_revision != file_info.gob_info.commit:  # noqa: E125
+            self._PurgeCaches()
+        self.gob_revision = file_info.gob_info.commit
 
-  def GetFileInfo(
-      self,
-      filename,  # type: Union[str, FileSpec]
-      fetch_html_content=False,  # type: bool
-      fetch_outline=True,  # type: bool
-      fetch_folding=False,  # type: bool
-      fetch_generated_from=False  # type: bool
-  ):
-    # type: (...) -> CsFile
-    """Return a CsFile object corresponding to the file named by |filename|.
+    def GetFileInfo(
+            self,
+            filename,  # type: Union[str, FileSpec]
+            fetch_html_content=False,  # type: bool
+            fetch_outline=True,  # type: bool
+            fetch_folding=False,  # type: bool
+            fetch_generated_from=False  # type: bool
+    ):
+        # type: (...) -> CsFile
+        """Return a CsFile object corresponding to the file named by |filename|.
 
     If |filename| is a FileSpec object, then that FileSpec object is used as-is
     to locate the file. Otherwise |filename| is resolved as a local path which
     should then map to a file known to CodeSearch."""
 
-    file_spec = self.GetFileSpec(filename)
+        file_spec = self.GetFileSpec(filename)
 
-    # If fetch_outline is present, then the result can be cached. It doesn't
-    # hurt for the cache entry to have extra data. I.e. it's okay for any of the
-    # other options to be true.
-    cacheable = fetch_outline
+        # If fetch_outline is present, then the result can be cached. It doesn't
+        # hurt for the cache entry to have extra data. I.e. it's okay for any of
+        # the other options to be true.
+        cacheable = fetch_outline
 
-    if cacheable and (file_spec.name in self.file_info_cache):
-      return self.file_info_cache[file_spec.name]
+        if cacheable and (file_spec.name in self.file_info_cache):
+            return self.file_info_cache[file_spec.name]
 
-    result = self.SendRequestToServer(
-        CompoundRequest(file_info_request=[
-            FileInfoRequest(
-                file_spec=self.GetFileSpec(filename),
-                fetch_html_content=fetch_html_content,
-                fetch_outline=fetch_outline,
-                fetch_folding=fetch_folding,
-                fetch_generated_from=fetch_generated_from)
-        ]))
+        result = self.SendRequestToServer(
+            CompoundRequest(file_info_request=[
+                FileInfoRequest(file_spec=self.GetFileSpec(filename),
+                                fetch_html_content=fetch_html_content,
+                                fetch_outline=fetch_outline,
+                                fetch_folding=fetch_folding,
+                                fetch_generated_from=fetch_generated_from)
+            ]))
 
-    if not result.file_info_response:
-      raise ServerError(
-          'unexpected message format while fetching file info for %s' %
-          (filename))
+        if not result.file_info_response:
+            raise ServerError(
+                'unexpected message format while fetching file info for %s' %
+                (filename))
 
-    if result.file_info_response[0].error_message:
-      raise ServerError(
-          'server reported error while fetching FileInfo: {}'.format(
-              result.file_info_response[0].error_message))
+        if result.file_info_response[0].error_message:
+            raise ServerError(
+                'server reported error while fetching FileInfo: {}'.format(
+                    result.file_info_response[0].error_message))
 
-    file_info = CsFile(self, file_info=result.file_info_response[0].file_info)
-    if cacheable:
-      self.file_info_cache[file_spec.name] = file_info
-    self._RefreshGobRevisionFromFileInfo(file_info.file_info)
-    return file_info
+        file_info = CsFile(self,
+                           file_info=result.file_info_response[0].file_info)
+        if cacheable:
+            self.file_info_cache[file_spec.name] = file_info
+        self._RefreshGobRevisionFromFileInfo(file_info.file_info)
+        return file_info
 
-  def GetSignatureForSymbol(self, filename, symbol):
-    # type: (str, str) -> str
-    """Return a signature matching |symbol| in |filename|.
+    def GetSignatureForSymbol(self, filename, symbol):
+        # type: (str, str) -> str
+        """Return a signature matching |symbol| in |filename|.
     """
 
-    fileinfo = self.GetFileInfo(filename)
-    types_haystack = frozenset([
-        AnnotationTypeValue.LINK_TO_DEFINITION,
-        AnnotationTypeValue.XREF_SIGNATURE
-    ])
+        fileinfo = self.GetFileInfo(filename)
+        types_haystack = frozenset([
+            AnnotationTypeValue.LINK_TO_DEFINITION,
+            AnnotationTypeValue.XREF_SIGNATURE
+        ])
 
-    for annotation in fileinfo.GetAnnotations():
-      if annotation.type.id not in types_haystack:
-        continue
+        for annotation in fileinfo.GetAnnotations():
+            if annotation.type.id not in types_haystack:
+                continue
 
-      if symbol not in fileinfo.Text(annotation.range):
-        continue
+            if symbol not in fileinfo.Text(annotation.range):
+                continue
 
-      sig = annotation.GetSignature()
-      if sig:
-        return sig
+            sig = annotation.GetSignature()
+            if sig:
+                return sig
 
-    raise NotFoundError(
-        "Can't determine signature for %s in %s" % (symbol, filename))
+        raise NotFoundError("Can't determine signature for %s in %s" %
+                            (symbol, filename))
 
-  def GetSignaturesForSymbol(self, filename, symbol, node_kind=None):
-    # type: (str, str, Optional[int]) -> List[str]
-    """Get all matching signatures given a symbol.
+    def GetSignaturesForSymbol(self, filename, symbol, node_kind=None):
+        # type: (str, str, Optional[int]) -> List[str]
+        """Get all matching signatures given a symbol.
 
     Returns all the signatures matching the given symbol in |filename|. If
     |node_kind| is not None, it is assumed to be one of the KytheNodeKind
@@ -962,40 +972,42 @@ class CodeSearch(object):
     the search failed.
     """
 
-    assert node_kind is None or KytheNodeKind.ToSymbol(node_kind) != node_kind
+        assert node_kind is None or KytheNodeKind.ToSymbol(
+            node_kind) != node_kind
 
-    signatures = set()  # type: Set[str]
-    fileinfo = self.GetFileInfo(filename)
-    matcher = SymbolSuffixMatcher(symbol)
-    types_haystack = frozenset([
-        AnnotationTypeValue.LINK_TO_DEFINITION,
-        AnnotationTypeValue.XREF_SIGNATURE
-    ])
+        signatures = set()  # type: Set[str]
+        fileinfo = self.GetFileInfo(filename)
+        matcher = SymbolSuffixMatcher(symbol)
+        types_haystack = frozenset([
+            AnnotationTypeValue.LINK_TO_DEFINITION,
+            AnnotationTypeValue.XREF_SIGNATURE
+        ])
 
-    for annotation in fileinfo.GetAnnotations():
-      if annotation.type.id not in types_haystack:
-        continue
+        for annotation in fileinfo.GetAnnotations():
+            if annotation.type.id not in types_haystack:
+                continue
 
-      text = fileinfo.Text(annotation.range)
-      if not matcher.Match(text):
-        continue
+            text = fileinfo.Text(annotation.range)
+            if not matcher.Match(text):
+                continue
 
-      if node_kind is not None and node_kind != annotation.kythe_xref_kind:
-        continue
+            if node_kind is not None \
+                and node_kind != annotation.kythe_xref_kind:  # noqa: E402
+                continue
 
-      signatures.update(annotation.GetSignatures())
+            signatures.update(annotation.GetSignatures())
 
-    return list(signatures)
+        return list(signatures)
 
-  def SearchForSymbol(
-      self,
-      symbol,  # type: str
-      xref_kind=NodeEnumKind.UNRESOLVED_TYPE,  # type: int
-      max_results_to_analyze=5,  # type: int
-      return_all_results=False  # type: bool
-  ):
-    # type: (...) -> List[XrefNode]
-    """Search for a specified symbol.
+    def SearchForSymbol(
+            self,
+            symbol,  # type: str
+            xref_kind=NodeEnumKind.UNRESOLVED_TYPE,  # type: int
+            max_results_to_analyze=5,  # type: int
+            return_all_results=False  # type: bool
+    ):
+        # type: (...) -> List[XrefNode]
+        """Search for a specified symbol.
 
     Use this when you know the symbol name and its type, and don't mind a few
     extra requests on the wire. It is possible that you'll end up with more
@@ -1014,145 +1026,147 @@ class CodeSearch(object):
     search will end as soon as at least one signature has been found.
     """
 
-    XREF_KIND_TO_SEARCH_PREFIX = {
-        NodeEnumKind.CLASS: "class:",
-        NodeEnumKind.FUNCTION: "function:",
-        NodeEnumKind.METHOD: "function:"
-    }
+        XREF_KIND_TO_SEARCH_PREFIX = {
+            NodeEnumKind.CLASS: "class:",
+            NodeEnumKind.FUNCTION: "function:",
+            NodeEnumKind.METHOD: "function:"
+        }
 
-    search_prefix = XREF_KIND_TO_SEARCH_PREFIX.get(xref_kind, "symbol:")
-    search_query = "{}{}".format(search_prefix, symbol)
+        search_prefix = XREF_KIND_TO_SEARCH_PREFIX.get(xref_kind, "symbol:")
+        search_query = "{}{}".format(search_prefix, symbol)
 
-    search_responses = self.SendRequestToServer(
-        CompoundRequest(search_request=[
-            SearchRequest(
-                query=search_query,
-                exhaustive=True,
-                max_num_results=max_results_to_analyze,
-                return_all_duplicates=False,
-                return_all_snippets=True,
-                return_decorated_snippets=False,
-                return_directories=False,
-                return_line_matches=True,
-                return_snippets=True)
-        ]))
-    if not search_responses.search_response:
-      return []
-    search_response = search_responses.search_response[0]
+        search_responses = self.SendRequestToServer(
+            CompoundRequest(search_request=[
+                SearchRequest(query=search_query,
+                              exhaustive=True,
+                              max_num_results=max_results_to_analyze,
+                              return_all_duplicates=False,
+                              return_all_snippets=True,
+                              return_decorated_snippets=False,
+                              return_directories=False,
+                              return_line_matches=True,
+                              return_snippets=True)
+            ]))
+        if not search_responses.search_response:
+            return []
+        search_response = search_responses.search_response[0]
 
-    signatures = set()  # type: Set[str]
-    result = None
-    for result in search_response.search_result:
-      assert isinstance(result, SearchResult)
+        signatures = set()  # type: Set[str]
+        result = None
+        for result in search_response.search_result:
+            assert isinstance(result, SearchResult)
 
-      for snippet in result.snippet:
-        for r in snippet.text.range:
-          try:
-            s = self.GetSignatureForLocation(
-                result.top_file.file.name,
-                snippet.first_line_number + r.range.end_line - 1,
-                r.range.end_column - 1)
-            signatures.add(s)
-          except:
-            # This usually means that there were no matches at the location. CS
-            # being CS, sometimes we need to resort to doing terrible things,
-            # like searching by symbol name.
-            sa = self.GetSignaturesForSymbol(result.top_file.file.name, symbol)
-            signatures.update(set(sa))
+            for snippet in result.snippet:
+                for r in snippet.text.range:
+                    try:
+                        s = self.GetSignatureForLocation(
+                            result.top_file.file.name,
+                            snippet.first_line_number + r.range.end_line - 1,
+                            r.range.end_column - 1)
+                        signatures.add(s)
+                    except Exception:
+                        # This usually means that there were no matches at the
+                        # location. CS being CS, sometimes we need to resort to
+                        # doing terrible things, like searching by symbol name.
+                        sa = self.GetSignaturesForSymbol(
+                            result.top_file.file.name, symbol)
+                        signatures.update(set(sa))
 
-            if len(sa) == 0:
-              # Well, that didn't work either. Let's try one more time and
-              # this time look up signatures that look like they are in the
-              # right ballpark. This is the least accurate of the methods
-              # available to us.
-              try:
-                s = self.GetSignatureForSymbol(result.top_file.file.name,
-                                               symbol)
-                signatures.add(s)
-              except:
-                pass
-            pass
+                        if len(sa) == 0:
+                            # Well, that didn't work either. Let's try one more
+                            # time and this time look up signatures that look
+                            # like they are in the right ballpark. This is the
+                            # least accurate of the methods available to us.
+                            try:
+                                s = self.GetSignatureForSymbol(
+                                    result.top_file.file.name, symbol)
+                                signatures.add(s)
+                            except Exception:
+                                pass
+                        pass
 
-      if not return_all_results and len(signatures) > 0:
-        break
+            if not return_all_results and len(signatures) > 0:
+                break
 
-    return [XrefNode.FromSignature(self, signature=s) for s in signatures]
+        return [
+            XrefNode.FromSignature(self, signature=sig) for sig in signatures
+        ]
 
-  def GetXrefsFor(self, signature, max_num_results=500):
-    # type: (str, int) -> List[XrefSearchResult]
-    refs = self.SendRequestToServer(
-        CompoundRequest(xref_search_request=[
-            XrefSearchRequest(
-                file_spec=self.GetFileSpec(),
-                query=signature,
-                max_num_results=max_num_results)
-        ]))
-    if not refs or not refs.xref_search_response:
-      return []
+    def GetXrefsFor(self, signature, max_num_results=500):
+        # type: (str, int) -> List[XrefSearchResult]
+        refs = self.SendRequestToServer(
+            CompoundRequest(xref_search_request=[
+                XrefSearchRequest(file_spec=self.GetFileSpec(),
+                                  query=signature,
+                                  max_num_results=max_num_results)
+            ]))
+        if not refs or not refs.xref_search_response:
+            return []
 
-    return refs.xref_search_response[0].search_result
+        return refs.xref_search_response[0].search_result
 
-  def GetOverridingDefinitions(self, signature):
-    # type: (str) -> List[XrefNode]
-    """GetOverridingDefinitions returns a list of XrefSearchResult objects
+    def GetOverridingDefinitions(self, signature):
+        # type: (str) -> List[XrefNode]
+        """GetOverridingDefinitions returns a list of XrefSearchResult objects
     representing all the overrides of the symbol corresponding to |signature|.
 
     Returns an empty list if there are no overrides.
     """
 
-    refs = self.GetXrefsFor(signature)
-    for result in refs:
-      result.match = list(
-          filter(lambda match: match.type_id == KytheXrefKind.OVERRIDDEN_BY,
-                 result.match))
+        refs = self.GetXrefsFor(signature)
+        for result in refs:
+            result.match = list(
+                filter(
+                    lambda match: match.type_id == KytheXrefKind.OVERRIDDEN_BY,
+                    result.match))
 
-    return XrefNode.FromSearchResults(
-        self, list(filter(lambda result: len(result.match) > 0, refs)))
+        return XrefNode.FromSearchResults(
+            self, list(filter(lambda result: len(result.match) > 0, refs)))
 
-  def GetCallTargets(self, signature):
-    # type: (str) -> List[XrefNode]
+    def GetCallTargets(self, signature):
+        # type: (str) -> List[XrefNode]
 
-    # First look up the declaration(s) for the callsite.
-    decl_signatures = []
-    for decl in self.GetXrefsFor(signature):
-      assert isinstance(decl, XrefSearchResult)
-      for match in decl.match:
-        assert isinstance(match, XrefSingleMatch)
-        if match.type_id not in (KytheXrefKind.DECLARATION,
-                                 KytheXrefKind.DEFINITION,
-                                 KytheXrefKind.OVERRIDDEN_BY):
-          continue
-        decl_signatures.append(match.signature)
+        # First look up the declaration(s) for the callsite.
+        decl_signatures = []
+        for decl in self.GetXrefsFor(signature):
+            assert isinstance(decl, XrefSearchResult)
+            for match in decl.match:
+                assert isinstance(match, XrefSingleMatch)
+                if match.type_id not in (KytheXrefKind.DECLARATION,
+                                         KytheXrefKind.DEFINITION,
+                                         KytheXrefKind.OVERRIDDEN_BY):
+                    continue
+                decl_signatures.append(match.signature)
 
-    # These are signatures of declarations or definions of symbols that could
-    # possibly override the call site.
-    candidates = []
-    for sig in decl_signatures:
-      candidates.extend(self.GetOverridingDefinitions(sig))
-    return candidates
+        # These are signatures of declarations or definions of symbols that
+        # could possibly override the call site.
+        candidates = []
+        for sig in decl_signatures:
+            candidates.extend(self.GetOverridingDefinitions(sig))
+        return candidates
 
-  def IsContentStale(self, filename, buffer_lines, check_prefix=False):
-    # type: (str, List[str], bool) -> bool
-    """Returns true if the file known to codesearch has different contents from
+    def IsContentStale(self, filename, buffer_lines, check_prefix=False):
+        # type: (str, List[str], bool) -> bool
+        """Returns true if the file known to codesearch has different contents from
     what's expected.
 
     |filename| specifies a file on disk (or just relative to the
     |source_root|).  |buffer_lines| is a list of strings containing the
     expected contents of the file.
-    
+
     If |check_prefix| is true, then only the first len(buffer_lines) lines of
     |filename| are compared.
     """
-    fileinfo = self.GetFileInfo(filename)
-    content_lines = fileinfo.lines
+        fileinfo = self.GetFileInfo(filename)
+        content_lines = fileinfo.lines
 
-    if check_prefix:
-      content_lines = content_lines[:len(buffer_lines)]
-      if len(content_lines) != len(buffer_lines):
-        return True
+        if check_prefix:
+            content_lines = content_lines[:len(buffer_lines)]
+            if len(content_lines) != len(buffer_lines):
+                return True
 
-    for left, right in zip(content_lines, buffer_lines):
-      if left != right:
-        return True
+        for left, right in zip(content_lines, buffer_lines):
+            if left != right:
+                return True
 
-    return False
+        return False

--- a/codesearch/compat.py
+++ b/codesearch/compat.py
@@ -8,28 +8,28 @@ import sys
 
 if sys.version_info[0] < 3:
 
-  def StringFromBytes(b):
-    return str(b)
+    def StringFromBytes(b):
+        return str(b)
 
-  def IsString(s):
-    return isinstance(s, basestring)
+    def IsString(s):
+        return isinstance(s, basestring)  # noqa
 
-  def ToStringSafe(s):
-    if isinstance(s, str):
-      return s
-    if isinstance(s, unicode):
-      return s.encode('utf-8')
-    return str(s)
+    def ToStringSafe(s):
+        if isinstance(s, str):
+            return s
+        if isinstance(s, unicode):  # noqa
+            return s.encode('utf-8')
+        return str(s)
 
 else:
 
-  def StringFromBytes(b):
-    return str(b, encoding='utf-8')
+    def StringFromBytes(b):
+        return str(b, encoding='utf-8')
 
-  def IsString(s):
-    return isinstance(s, str)
+    def IsString(s):
+        return isinstance(s, str)
 
-  def ToStringSafe(s):
-    if isinstance(s, str):
-      return s
-    return str(s)
+    def ToStringSafe(s):
+        if isinstance(s, str):
+            return s
+        return str(s)

--- a/codesearch/file_cache.py
+++ b/codesearch/file_cache.py
@@ -15,127 +15,133 @@ import datetime
 
 
 def StableFilenameForUrl(url):
-  return hashlib.sha1(url.encode('utf-8')).hexdigest()
+    return hashlib.sha1(url.encode('utf-8')).hexdigest()
 
 
 class FileCache:
+    def __init__(self, cache_dir=None, expiration_in_seconds=1800):
 
-  def __init__(self, cache_dir=None, expiration_in_seconds=1800):
+        # Protects |self| but individual file objects in |store| are not
+        # protected once its returned from |_file_for|.
+        self.lock = threading.Lock()
 
-    # Protects |self| but individual file objects in |store| are not
-    # protected once its returned from |_file_for|.
-    self.lock = threading.Lock()
+        # Dictionary mapping a URL to a tuple containing a file object and a
+        # timestamp. The timestamp notes the creation time.
+        self.store = {}
 
-    # Dictionary mapping a URL to a tuple containing a file object and a
-    # timestamp. The timestamp notes the creation time.
-    self.store = {}
+        # Directory containing cache files. If |cache_dir| is None, then each
+        # file is created independently using tempfile.TemporaryFile().
+        self.cache_dir = cache_dir
 
-    # Directory containing cache files. If |cache_dir| is None, then each
-    # file is created independently using tempfile.TemporaryFile().
-    self.cache_dir = cache_dir
+        self.expiration = datetime.timedelta(seconds=expiration_in_seconds)
 
-    self.expiration = datetime.timedelta(seconds=expiration_in_seconds)
-
-    # Garbage collector timer.
-    # Add 2 seconds so that file timestamp comparisons will work as expected on
-    # filesystems where timestamps aren't very accurate.
-    self.timer = threading.Timer(self.expiration.total_seconds() + 2, self.gc)
-    self.timer.start()
-
-    if cache_dir and not os.path.exists(cache_dir):
-      if not os.path.isabs(cache_dir):
-        raise ValueError('|cache_dir| should be an absolute path')
-      os.makedirs(cache_dir)
-
-  def _file_for(self, url, create=False):
-    with self.lock:
-      if url in self.store:
-        f, _ = self.store[url]
-        f.seek(0)
-
-      elif create and self.cache_dir is None:
-        f = tempfile.TemporaryFile(mode='w+b')
-        f.seek(0)
-
-      elif self.cache_dir:
-        deterministic_filename = os.path.join(self.cache_dir,
-                                              StableFilenameForUrl(url))
-        if os.path.exists(deterministic_filename):
-          st = os.stat(deterministic_filename)
-          if create:
-            f = open(deterministic_filename, 'w+b')
-          elif datetime.datetime.utcfromtimestamp(st.st_mtime) + \
-                  self.expiration > datetime.datetime.utcnow():
-            f = open(deterministic_filename, 'r+b')
-            self.store[url] = (f,
-                               datetime.datetime.utcfromtimestamp(st.st_mtime))
-          else:
-            # Existing file has expired.
-            os.remove(deterministic_filename)
-            return None
-        else:
-          if create:
-            f = open(deterministic_filename, 'w+b')
-          else:
-            return None
-      else:
-        return None
-
-      if url not in self.store:
-        self.store[url] = (f, datetime.datetime.now())
-      return f
-
-  def put(self, url, data):
-    """Store |data| as the response for |url|."""
-    f = self._file_for(url, create=True)
-    if f is None:
-      return
-
-    f.write(data)
-    f.flush()
-
-  def get(self, url):
-    """Get response data for |url|."""
-    f = self._file_for(url, create=False)
-    if f is None:
-      return ''
-    f.seek(0)
-    return f.read()
-
-  def gc(self, purge=True):
-    """Garbage collect. Should be invoked periodically to keep cache directory clean."""
-    dir_to_purge = None
-    expiration = None
-    with self.lock:
-      expired = datetime.datetime.now() - self.expiration
-      remove = []
-      for url, (_, timestamp) in self.store.items():
-        if purge or timestamp < expired:
-          remove.append(url)
-      for url in remove:
-        self.store.pop(url)
-      if not purge:
-        if self.timer is not None:
-          self.timer.cancel()
-        self.timer = threading.Timer(15 * 60, self.gc)
+        # Garbage collector timer.  Add 2 seconds so that file timestamp
+        # comparisons will work as expected on filesystems where timestamps
+        # aren't very accurate.
+        self.timer = threading.Timer(self.expiration.total_seconds() + 2,
+                                     self.gc)
         self.timer.start()
-      dir_to_purge = self.cache_dir
-      expiration = self.expiration
 
-    # This part doesn't require a lock on |self|.
-    if not dir_to_purge:
-      return
+        if cache_dir and not os.path.exists(cache_dir):
+            if not os.path.isabs(cache_dir):
+                raise ValueError('|cache_dir| should be an absolute path')
+            os.makedirs(cache_dir)
 
-    now = datetime.datetime.utcnow()
-    for entry in os.listdir(dir_to_purge):
-      full_path = os.path.join(dir_to_purge, entry)
-      st = os.stat(full_path)
-      expires_on = datetime.datetime.utcfromtimestamp(st.st_mtime) + expiration
-      if purge or expires_on < now:
-        os.remove(full_path)
+    def _file_for(self, url, create=False):
+        with self.lock:
+            if url in self.store:
+                f, _ = self.store[url]
+                f.seek(0)
 
-  def close(self):
-    """Stop using this FileCache. Should be called for every FileCache instance."""
-    self.timer.cancel()
-    for f, _ in self.store.values():
-      f.close()
+            elif create and self.cache_dir is None:
+                f = tempfile.TemporaryFile(mode='w+b')
+                f.seek(0)
+
+            elif self.cache_dir:
+                deterministic_filename = os.path.join(self.cache_dir,
+                                                      StableFilenameForUrl(url))
+                if os.path.exists(deterministic_filename):
+                    st = os.stat(deterministic_filename)
+                    if create:
+                        f = open(deterministic_filename, 'w+b')
+                    elif datetime.datetime.utcfromtimestamp(st.st_mtime) + \
+                            self.expiration > datetime.datetime.utcnow():
+                        f = open(deterministic_filename, 'r+b')
+                        self.store[url] = (f,
+                                           datetime.datetime.utcfromtimestamp(
+                                               st.st_mtime))
+                    else:
+                        # Existing file has expired.
+                        os.remove(deterministic_filename)
+                        return None
+                else:
+                    if create:
+                        f = open(deterministic_filename, 'w+b')
+                    else:
+                        return None
+            else:
+                return None
+
+            if url not in self.store:
+                self.store[url] = (f, datetime.datetime.now())
+            return f
+
+    def put(self, url, data):
+        """Store |data| as the response for |url|."""
+        f = self._file_for(url, create=True)
+        if f is None:
+            return
+
+        f.write(data)
+        f.flush()
+
+    def get(self, url):
+        """Get response data for |url|."""
+        f = self._file_for(url, create=False)
+        if f is None:
+            return ''
+        f.seek(0)
+        return f.read()
+
+    def gc(self, purge=True):
+        """Garbage collect.
+
+    Should be invoked periodically to keep cache directory clean."""
+        dir_to_purge = None
+        expiration = None
+        with self.lock:
+            expired = datetime.datetime.now() - self.expiration
+            remove = []
+            for url, (_, timestamp) in self.store.items():
+                if purge or timestamp < expired:
+                    remove.append(url)
+            for url in remove:
+                self.store.pop(url)
+            if not purge:
+                if self.timer is not None:
+                    self.timer.cancel()
+                self.timer = threading.Timer(15 * 60, self.gc)
+                self.timer.start()
+            dir_to_purge = self.cache_dir
+            expiration = self.expiration
+
+        # This part doesn't require a lock on |self|.
+        if not dir_to_purge:
+            return
+
+        now = datetime.datetime.utcnow()
+        for entry in os.listdir(dir_to_purge):
+            full_path = os.path.join(dir_to_purge, entry)
+            st = os.stat(full_path)
+            expires_on = datetime.datetime.utcfromtimestamp(
+                st.st_mtime) + expiration
+            if purge or expires_on < now:
+                os.remove(full_path)
+
+    def close(self):
+        """Stop using this FileCache.
+
+    Should be called for every FileCache instance."""
+        self.timer.cancel()
+        for f, _ in self.store.values():
+            f.close()

--- a/codesearch/language_utils.py
+++ b/codesearch/language_utils.py
@@ -10,7 +10,7 @@ TOKEN_BOUNDARIES = r'[-!"#%&\'()*+,./:;<=>?\[\\\]^{|}~ ]'
 
 
 def CppIdentifierTokens(s):
-  """Returns an array of C++ identifier tokens in |s|.
+    """Returns an array of C++ identifier tokens in |s|.
 
     >>> CppIdentifierTokens('abc')
     ['abc']
@@ -27,11 +27,12 @@ def CppIdentifierTokens(s):
     >>> CppIdentifierTokens('a&(b*c)[d^e/f]g{}h|i')
     ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']
     """
-  return [token for token in re.split(TOKEN_BOUNDARIES, s) if token]
+    return [token for token in re.split(TOKEN_BOUNDARIES, s) if token]
 
 
 def MatchSymbolSuffix(haystack_string, needle_string):
-  """Returns true if the symbols in |haystack_string| ends with the symbols in |needle_string|.
+    """Returns true if the symbols in |haystack_string| ends with the symbols in
+|needle_string|.
 
     >>> MatchSymbolSuffix("abc::def", "def")
     True
@@ -51,13 +52,13 @@ def MatchSymbolSuffix(haystack_string, needle_string):
     >>> MatchSymbolSuffix("foo|bar  baz", "bar baz")
     True
     """
-  haystack = CppIdentifierTokens(haystack_string)
-  needle = CppIdentifierTokens(needle_string)
-  return haystack[-len(needle):] == needle
+    haystack = CppIdentifierTokens(haystack_string)
+    needle = CppIdentifierTokens(needle_string)
+    return haystack[-len(needle):] == needle
 
 
 class SymbolSuffixMatcher(object):
-  """Like MatchSymbolSuffix, but caches preprocessed |needle|.
+    """Like MatchSymbolSuffix, but caches preprocessed |needle|.
 
     >>> SymbolSuffixMatcher("def").Match("abc::def")
     True
@@ -70,20 +71,20 @@ class SymbolSuffixMatcher(object):
 
     >>> SymbolSuffixMatcher("abc::def").Match("a:abc def")
     True
-    
+
     >>> SymbolSuffixMatcher("abc::def").Match("aabc def")
     False
     """
 
-  def __init__(self, needle):
-    self.needle = CppIdentifierTokens(needle)
+    def __init__(self, needle):
+        self.needle = CppIdentifierTokens(needle)
 
-  def Match(self, haystack):
-    return CppIdentifierTokens(haystack)[-len(self.needle):] == self.needle
+    def Match(self, haystack):
+        return CppIdentifierTokens(haystack)[-len(self.needle):] == self.needle
 
 
 def IsIdentifier(s):
-  """Returns True if |s| is a valid C++ identifier.
+    """Returns True if |s| is a valid C++ identifier.
 
     >>> IsIdentifier('abc')
     True
@@ -94,10 +95,10 @@ def IsIdentifier(s):
     >>> IsIdentifier('abc:')
     False
     """
-  return CppIdentifierTokens(s)[0] == s
+    return CppIdentifierTokens(s)[0] == s
 
 
 # For running doctests.
 if __name__ == "__main__":
-  import doctest
-  doctest.testmod()
+    import doctest
+    doctest.testmod()

--- a/codesearch/messages.py
+++ b/codesearch/messages.py
@@ -5,1727 +5,1740 @@
 # https://developers.google.com/open-source/licenses/bsd.
 
 import json
-import sys
-import os
 
 from .compat import IsString, ToStringSafe
 
 # For type checking. Not needed at runtime.
 try:
-  from typing import Any, Optional, List, Dict, Union, Type, Tuple
+    from typing import Any, Optional, List, Dict, Union, Type, Tuple
 except ImportError:
-  pass
+    pass
 
 
 class CodeSearchProtoJsonEncoder(json.JSONEncoder):
-
-  def default(self, o):
-    if isinstance(o, Message):
-      return o.__dict__
-    return o
+    def default(self, o):
+        if isinstance(o, Message):
+            return o.__dict__
+        return o
 
 
 class CodeSearchProtoJsonSymbolizedEncoder(json.JSONEncoder):
-
-  def default(self, o):
-    if isinstance(o, Message):
-      rv = {}
-      desc = o.__class__.DESCRIPTOR
-      for k, v in o.__dict__.items():
-        if k in desc:
-          if not isinstance(desc[k], list) and \
-              issubclass(desc[k], Message) and \
-              desc[k].IsEnum():
-            rv[k] = desc[k].ToSymbol(v)
-          elif desc[k] == str and IsString(v) and not v:
-            pass
-          elif isinstance(desc[k], list) and \
-              isinstance(v, list) and \
-              len(v) == 0:
-            pass
-          elif v is None:
-            pass
-          else:
-            rv[k] = v
-        else:
-          rv[k] = v
-      return rv
-    return o
+    def default(self, o):
+        if isinstance(o, Message):
+            rv = {}
+            desc = o.__class__.DESCRIPTOR
+            for k, v in o.__dict__.items():
+                if k in desc:
+                    if not isinstance(desc[k], list) and \
+                        issubclass(desc[k], Message) and \
+                        desc[k].IsEnum():  # noqa: E125
+                        rv[k] = desc[k].ToSymbol(v)
+                    elif desc[k] == str and IsString(v) and not v:
+                        pass
+                    elif isinstance(desc[k], list) and \
+                        isinstance(v, list) and \
+                        len(v) == 0:  # noqa: E125
+                        pass
+                    elif v is None:
+                        pass
+                    else:
+                        rv[k] = v
+                else:
+                    rv[k] = v
+            return rv
+        return o
 
 
 def StringifyObject(o, target_type):
+    def stringify_lines(o, level):
+        indent = '  ' * level
+        lines = [indent + '{']
+        for k, v in vars(o).items():
+            if isinstance(v, target_type):
+                lines.append(indent + '  {}:'.format(k))
+                lines.extend(stringify_lines(v, level + 1))
+            else:
+                lines.append(indent + '  {}: {}'.format(k, repr(v)))
+        lines.append(indent + '}')
+        return lines
 
-  def stringify_lines(o, level):
-    indent = '  ' * level
-    lines = [indent + '{']
-    for k, v in vars(o).items():
-      if isinstance(v, target_type):
-        lines.append(indent + '  {}:'.format(k))
-        lines.extend(stringify_lines(v, level + 1))
-      else:
-        lines.append(indent + '  {}: {}'.format(k, repr(v)))
-    lines.append(indent + '}')
-    return lines
-
-  return '\n'.join(stringify_lines(o, 0))
+    return '\n'.join(stringify_lines(o, 0))
 
 
 def AttemptToFixupInvalidUtf8(s):
-  """Try to recover invalid UTF-8 by replacing invalid bytes.
-   
+    """Try to recover invalid UTF-8 by replacing invalid bytes.
+
     The response from the server is not guaranteed to be valid UTF-8.  This
     function attempts to recover incorrect UTF-8. We may still run into issues
     due to a botched recovery, but this response is already doomed."""
 
-  def FixupByteArray(s):
-    return s.decode(encoding='utf-8', errors='replace')
+    def FixupByteArray(s):
+        return s.decode(encoding='utf-8', errors='replace')
 
-  def FixupString(s):
-    return str.decode(encoding='utf-8', errors='replace')
+    def FixupString(s):
+        return str.decode(encoding='utf-8', errors='replace')
 
-  if isinstance(s, bytearray):
-    return FixupByteArray(s)
+    if isinstance(s, bytearray):
+        return FixupByteArray(s)
 
-  if isinstance(s, bytes):
-    return FixupByteArray(bytearray(s))
+    if isinstance(s, bytes):
+        return FixupByteArray(bytearray(s))
 
-  if isinstance(s, str):
-    return FixupString(s)
+    if isinstance(s, str):
+        return FixupString(s)
 
-  return None
+    return None
 
 
 class Message(object):
+    class PARENT_TYPE:
+        pass
 
-  class PARENT_TYPE:
-    pass
+    def AsQueryString(self):
+        # type: () -> List[Tuple[str,str]]
+        values = []  # type: List[Tuple[str,str]]
+        for k, v in sorted(self.__dict__.items()):
+            values.extend(Message.ToQueryString(k, v))
+        return values
 
-  def AsQueryString(self):
-    # type: () -> List[Tuple[str,str]]
-    values = []  # type: List[Tuple[str,str]]
-    for k, v in sorted(self.__dict__.items()):
-      values.extend(Message.ToQueryString(k, v))
-    return values
+    def __str__(self):
+        return StringifyObject(self, Message)
 
-  def __str__(self):
-    return StringifyObject(self, Message)
+    @staticmethod
+    def ToQueryString(k, o):
+        # type: (str, Any) -> List[Tuple[str,str]]
+        if o is None:
+            return []
+        if isinstance(o, Message):
+            return [(k, 'b')] + o.AsQueryString() + [(k, 'e')]
+        if isinstance(o, bool):
+            return [(k, 'true' if o else 'false')]
+        if isinstance(o, list):
+            values = []
+            for v in o:
+                values.extend(Message.ToQueryString(k, v))
+            return values
+        if isinstance(o, str) and not o:
+            return []
+        return [(k, str(o))]
 
-  @staticmethod
-  def ToQueryString(k, o):
-    # type: (str, Any) -> List[Tuple[str,str]]
-    if o is None:
-      return []
-    if isinstance(o, Message):
-      return [(k, 'b')] + o.AsQueryString() + [(k, 'e')]
-    if isinstance(o, bool):
-      return [(k, 'true' if o else 'false')]
-    if isinstance(o, list):
-      values = []
-      for v in o:
-        values.extend(Message.ToQueryString(k, v))
-      return values
-    if isinstance(o, str) and not o:
-      return []
-    return [(k, str(o))]
+    @staticmethod
+    def Coerce(source, target_type, parent_class=None):
+        if isinstance(target_type, list):
+            assert isinstance(source, list)
+            assert len(target_type) == 1
 
-  @staticmethod
-  def Coerce(source, target_type, parent_class=None):
-    if isinstance(target_type, list):
-      assert isinstance(source, list)
-      assert len(target_type) == 1
+            return [
+                Message.Coerce(x, target_type[0], parent_class) for x in source
+            ]
 
-      return [Message.Coerce(x, target_type[0], parent_class) for x in source]
+        if target_type == Message.PARENT_TYPE:
+            assert parent_class is not None
+            return Message.Coerce(source, parent_class, parent_class)
 
-    if target_type == Message.PARENT_TYPE:
-      assert parent_class is not None
-      return Message.Coerce(source, parent_class, parent_class)
+        if issubclass(target_type, Message):
+            if source.__class__ == target_type:
+                return source
 
-    if issubclass(target_type, Message):
-      if source.__class__ == target_type:
-        return source
+            descriptor = target_type.DESCRIPTOR
 
-      descriptor = target_type.DESCRIPTOR
+            if isinstance(descriptor, dict):
+                assert isinstance(
+                    source,
+                    dict), 'Source is not a dictionary: %s; Mapping to %s' % (
+                        source, target_type)
+                dest = {}
+                for k, v in source.items():
+                    if k in descriptor:
+                        dest[k] = Message.Coerce(v, descriptor[k], target_type)
+                    else:
+                        dest[k] = v
+                return target_type(**dest)
 
-      if isinstance(descriptor, dict):
-        assert isinstance(
-            source, dict), 'Source is not a dictionary: %s; Mapping to %s' % (
-                source, target_type)
-        dest = {}
-        for k, v in source.items():
-          if k in descriptor:
-            dest[k] = Message.Coerce(v, descriptor[k], target_type)
-          else:
-            dest[k] = v
-        return target_type(**dest)
+            if descriptor is None:
+                assert isinstance(source, dict)
+                m = Message()
+                m.__dict__ = source.copy()
+                return m
 
-      if descriptor is None:
-        assert isinstance(source, dict)
-        m = Message()
-        m.__dict__ = source.copy()
-        return m
+            if descriptor != str and IsString(source):
+                if hasattr(target_type, source):
+                    return descriptor(getattr(target_type, source))
+                raise ValueError(
+                    "unrecognized symbolic enum value \"{}\" for {}".format(
+                        source, str(target_type)))
+            return descriptor(source)
+        if target_type == str and IsString(source):
+            return ToStringSafe(source)
+        return target_type(source)
 
-      if descriptor != str and IsString(source):
-        if hasattr(target_type, source):
-          return descriptor(getattr(target_type, source))
-        raise ValueError(
-            "unrecognized symbolic enum value \"{}\" for {}".format(
-                source, str(target_type)))
-      return descriptor(source)
-    if target_type == str and IsString(source):
-      return ToStringSafe(source)
-    return target_type(source)
+    @classmethod
+    def IsEnum(cls):
+        return not isinstance(cls.DESCRIPTOR, dict)
 
-  @classmethod
-  def IsEnum(cls):
-    return not isinstance(cls.DESCRIPTOR, dict)
+    @classmethod
+    def ToSymbol(cls, v):
+        assert cls.IsEnum()
+        for prop, value in vars(cls).items():
+            if value == v:
+                return prop
+        return v
 
-  @classmethod
-  def ToSymbol(cls, v):
-    assert cls.IsEnum()
-    for prop, value in vars(cls).items():
-      if value == v:
-        return prop
-    return v
+    @classmethod
+    def FromSymbol(cls, s):
+        assert cls.IsEnum()
+        return vars(cls)[s]
 
-  @classmethod
-  def FromSymbol(cls, s):
-    assert cls.IsEnum()
-    return vars(cls)[s]
+    @classmethod
+    def Make(cls, **kwargs):
+        return Message.Coerce(kwargs, cls)
 
-  @classmethod
-  def Make(cls, **kwargs):
-    return Message.Coerce(kwargs, cls)
+    @classmethod
+    def FromShallowDict(cls, d):
+        return Message.Coerce(d, cls)
 
-  @classmethod
-  def FromShallowDict(cls, d):
-    return Message.Coerce(d, cls)
+    @classmethod
+    def FromJsonString(cls, s):
+        try:
+            if isinstance(s, bytes) or isinstance(s, bytearray):
+                s = s.decode(encoding='utf-8')
+            d = json.loads(s)
 
-  @classmethod
-  def FromJsonString(cls, s):
-    try:
-      if isinstance(s, bytes) or isinstance(s, bytearray):
-        s = s.decode(encoding='utf-8')
-      d = json.loads(s)
+        except UnicodeError as e:
+            # The server sent us something that can't be decoded. It's probably
+            # not valid UTF-8.  Rather than giving up, let's try to fix up the
+            # string so that we can move on. Usually the problem is that there's
+            # an errant byte that needs to be replaced with something else.
 
-    except UnicodeError as e:
-      # The server sent us something that can't be decoded. It's probably not
-      # valid UTF-8.  Rather than giving up, let's try to fix up the string so
-      # that we can move on. Usually the problem is that there's an errant byte
-      # that needs to be replaced with something else.
+            s = AttemptToFixupInvalidUtf8(s)
+            if s:
+                d = json.loads(s)
+            else:
+                raise ValueError(
+                    'Error while decoding {o}. {reason} at offset {start}'.
+                    format(o=repr(e.object), reason=e.reason, start=e.start))
 
-      s = AttemptToFixupInvalidUtf8(s)
-      if s:
-        d = json.loads(s)
-      else:
-        raise ValueError(
-            'Error while decoding {o}. {reason} at offset {start}'.format(
-                o=repr(e.object), reason=e.reason, start=e.start))
-
-    except ValueError as e:
-      import tempfile
-      error_file_name = None
-      with tempfile.NamedTemporaryFile(
-          delete=False, prefix='codesearch_error_') as f:
-        f.write("""Error while decoding JSON response.
+        except ValueError as e:
+            import tempfile
+            error_file_name = None
+            with tempfile.NamedTemporaryFile(delete=False,
+                                             prefix='codesearch_error_') as f:
+                f.write("""Error while decoding JSON response.
 
 Message: {msg}
 Content follows this line: ----
 {content}
 """.format(msg=e.message, content=s))
-        error_file_name = f.name
-      raise ValueError(
-          'Error while decoding JSON response. Report saved to {}'.format(
-              error_file_name))
+                error_file_name = f.name
+            raise ValueError(
+                'Error while decoding JSON response. Report saved to {}'.format(
+                    error_file_name))
 
-    return cls.FromShallowDict(d)
+        return cls.FromShallowDict(d)
 
-  DESCRIPTOR = None  # type: Union[None, Type[int], Dict[str, Any]]
+    DESCRIPTOR = None  # type: Union[None, Type[int], Dict[str, Any]]
 
 
 class AnnotationTypeValue(Message):
-  BLAME = 0x00040
-  CODE_FINDINGS = 0x40000
-  COMPILER = 0x00080
-  COVERAGE = 0x00010
-  DEPRECATED = 0x02000
-  FINDBUGS = 0x00200
-  LANG_COUNT = 0x04000
-  LINK_TO_DEFINITION = 0x00001
-  LINK_TO_URL = 0x00002
-  LINT = 0x00020
-  OFFLINE_QUERIES = 0x08000
-  OVERRIDE = 0x01000
-  TOOLS = 0x20000
-  UNKNOWN = 0x00000
-  XREF_SIGNATURE = 0x00004
+    BLAME = 0x00040
+    CODE_FINDINGS = 0x40000
+    COMPILER = 0x00080
+    COVERAGE = 0x00010
+    DEPRECATED = 0x02000
+    FINDBUGS = 0x00200
+    LANG_COUNT = 0x04000
+    LINK_TO_DEFINITION = 0x00001
+    LINK_TO_URL = 0x00002
+    LINT = 0x00020
+    OFFLINE_QUERIES = 0x08000
+    OVERRIDE = 0x01000
+    TOOLS = 0x20000
+    UNKNOWN = 0x00000
+    XREF_SIGNATURE = 0x00004
 
-  DESCRIPTOR = int
+    DESCRIPTOR = int
 
 
 class AnnotationType(Message):
-  DESCRIPTOR = {
-      'id': AnnotationTypeValue,
-  }
+    DESCRIPTOR = {
+        'id': AnnotationTypeValue,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.id = d.get('id', AnnotationTypeValue.UNKNOWN)  # type: int
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.id = d.get('id', AnnotationTypeValue.UNKNOWN)  # type: int
 
 
 class TextRange(Message):
-  """A range inside a source file. All indices are 1-based and inclusive."""
-  DESCRIPTOR = {
-      'start_line': int,
-      'start_column': int,
-      'end_line': int,
-      'end_column': int,
-  }
+    """A range inside a source file. All indices are 1-based and inclusive."""
+    DESCRIPTOR = {
+        'start_line': int,
+        'start_column': int,
+        'end_line': int,
+        'end_column': int,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.start_line = d.get('start_line', 0)
-    self.end_line = d.get('end_line', 0)
-    self.start_column = d.get('start_column', 0)
-    self.end_column = d.get('end_column', 0)
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.start_line = d.get('start_line', 0)
+        self.end_line = d.get('end_line', 0)
+        self.start_column = d.get('start_column', 0)
+        self.end_column = d.get('end_column', 0)
 
-  def Contains(self, line, column):
-    return not (line < self.start_line or line > self.end_line or
-                (line == self.start_line and column < self.start_column) or
-                (line == self.end_line and column > self.end_column))
+    def Contains(self, line, column):
+        return not (line < self.start_line or line > self.end_line or
+                    (line == self.start_line and column < self.start_column) or
+                    (line == self.end_line and column > self.end_column))
 
-  def Overlaps(self, other):
-    assert isinstance(other, TextRange)
+    def Overlaps(self, other):
+        assert isinstance(other, TextRange)
 
-    def _RangeOverlap(s1, e1, s2, e2):
-      """Returns true if the range [s1,e1] and [s2,e2] intersects. The
+        def _RangeOverlap(s1, e1, s2, e2):
+            """Returns true if the range [s1,e1] and [s2,e2] intersects. The
           ranges are inclusive."""
-      return (s1 <= e1 and s2 <= e2) and not (e1 < s2 or e2 < s1)
+            return (s1 <= e1 and s2 <= e2) and not (e1 < s2 or e2 < s1)
 
-    if not self.IsValid() or not other.IsValid():
-      return False
+        if not self.IsValid() or not other.IsValid():
+            return False
 
-    if not _RangeOverlap(self.start_line, self.end_line, other.start_line,
-                         other.end_line):
-      return False
+        if not _RangeOverlap(self.start_line, self.end_line, other.start_line,
+                             other.end_line):
+            return False
 
-    if _RangeOverlap(self.start_line + 1, self.end_line - 1,
-                     other.start_line + 1, other.end_line - 1):
-      return True
+        if _RangeOverlap(self.start_line + 1, self.end_line - 1,
+                         other.start_line + 1, other.end_line - 1):
+            return True
 
-    if self.end_line == other.start_line and self.end_column < other.start_column:
-      return False
+        if self.end_line == other.start_line and \
+           self.end_column < other.start_column:
+            return False
 
-    if other.end_line == self.start_line and other.end_column < self.start_column:
-      return False
+        if other.end_line == self.start_line and \
+           other.end_column < self.start_column:
+            return False
 
-    return True
+        return True
 
-  def IsValid(self):
-    return \
-        self.start_line != 0 or \
-        self.start_column != 0 or \
-        self.end_line != 0 or \
-        self.end_column != 0
+    def IsValid(self):
+        return \
+            self.start_line != 0 or \
+            self.start_column != 0 or \
+            self.end_line != 0 or \
+            self.end_column != 0
 
-  def Empty(self):
-    return not self.IsValid()
+    def Empty(self):
+        return not self.IsValid()
 
-  def __eq__(self, other):
-    if not isinstance(other, TextRange):
-      return False
+    def __eq__(self, other):
+        if not isinstance(other, TextRange):
+            return False
 
-    if not self.IsValid() or other.IsValid():
-      return False
+        if not self.IsValid() or other.IsValid():
+            return False
 
-    return self.start_line == other.start_line and \
-            self.start_column == other.start_column and \
-            self.end_line == other.end_line and \
-            self.end_column == other.end_column
+        return self.start_line == other.start_line and \
+                self.start_column == other.start_column and \
+                self.end_line == other.end_line and \
+                self.end_column == other.end_column  # noqa: E125
 
 
 class InternalLink(Message):
-  DESCRIPTOR = {
-      'package_name': str,
-      'highlight_signature': str,  # A ' ' delimited list of tickets.
-      'signature': str,  # A ' ' delimited list of tickets.
-      'signature_hash': str,  # Always '' for Kythe.
-      'path': str,
+    DESCRIPTOR = {
+        'package_name': str,
+        'highlight_signature': str,  # A ' ' delimited list of tickets.
+        'signature': str,  # A ' ' delimited list of tickets.
+        'signature_hash': str,  # Always '' for Kythe.
+        'path': str,
 
-      # The range in the target path that should be considered the target of the
-      # link.
-      'range': TextRange,
-  }
+        # The range in the target path that should be considered the target of
+        # the link.
+        'range': TextRange,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.package_name = d.get('package_name', str())  # type: str
-    self.highlight_signature = d.get('highlight_signature', str())  # type: str
-    self.signature = d.get('signature', str())  # type: str
-    self.signature_hash = d.get('signature_hash', str())  # type: str
-    self.path = d.get('path', str())  # type: str
-    self.range = d.get('range', TextRange())  # type: TextRange
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.package_name = d.get('package_name', str())  # type: str
+        self.highlight_signature = d.get('highlight_signature',
+                                         str())  # type: str
+        self.signature = d.get('signature', str())  # type: str
+        self.signature_hash = d.get('signature_hash', str())  # type: str
+        self.path = d.get('path', str())  # type: str
+        self.range = d.get('range', TextRange())  # type: TextRange
 
-  def MatchesSignature(self, signature):
-    return signature in getattr(self, 'highlight_signature',
-                                '').split(' ') or (signature in getattr(
-                                    self, 'signature', '').split(' '))
+    def MatchesSignature(self, signature):
+        return signature in getattr(self, 'highlight_signature',
+                                    '').split(' ') or (signature in getattr(
+                                        self, 'signature', '').split(' '))
 
-  def GetSignatures(self):
-    # type: () -> List[str]
-    sigs = []
-    if self.signature:
-      sigs.extend(self.signature.split(' '))
-    if self.highlight_signature:
-      sigs.extend(self.highlight_signature.split(' '))
-    return sigs
+    def GetSignatures(self):
+        # type: () -> List[str]
+        sigs = []
+        if self.signature:
+            sigs.extend(self.signature.split(' '))
+        if self.highlight_signature:
+            sigs.extend(self.highlight_signature.split(' '))
+        return sigs
 
-  def GetSignature(self):
-    # type: () -> str
-    sigs = self.GetSignatures()
-    if len(sigs) == 0:
-      return ""
-    return sigs[0]
+    def GetSignature(self):
+        # type: () -> str
+        sigs = self.GetSignatures()
+        if len(sigs) == 0:
+            return ""
+        return sigs[0]
 
 
 class XrefSignature(Message):
-  DESCRIPTOR = {
-      'highlight_signature': str,  # A space delimited list of tickets.
-      'signature': str,  # A space delimited list of tickets.
-      'signature_hash': str,  # Always '' for Kythe.
-  }
+    DESCRIPTOR = {
+        'highlight_signature': str,  # A space delimited list of tickets.
+        'signature': str,  # A space delimited list of tickets.
+        'signature_hash': str,  # Always '' for Kythe.
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.highlight_signature = d.get('highlight_signature', str())  # type: str
-    self.signature = d.get('signature', str())  # type: str
-    self.signature_hash = d.get('signature_hash', str())  # type: str
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.highlight_signature = d.get('highlight_signature',
+                                         str())  # type: str
+        self.signature = d.get('signature', str())  # type: str
+        self.signature_hash = d.get('signature_hash', str())  # type: str
 
-  def MatchesSignature(self, signature):
-    return signature in getattr(self, 'highlight_signature',
-                                '').split(' ') or (signature in getattr(
-                                    self, 'signature', '').split(' '))
+    def MatchesSignature(self, signature):
+        return signature in getattr(self, 'highlight_signature',
+                                    '').split(' ') or (signature in getattr(
+                                        self, 'signature', '').split(' '))
 
-  def GetSignatures(self):
-    # type: () -> List[str]
-    sigs = []
-    if self.signature:
-      sigs.extend(self.signature.split(' '))
-    if self.highlight_signature:
-      sigs.extend(self.highlight_signature.split(' '))
-    return sigs
+    def GetSignatures(self):
+        # type: () -> List[str]
+        sigs = []
+        if self.signature:
+            sigs.extend(self.signature.split(' '))
+        if self.highlight_signature:
+            sigs.extend(self.highlight_signature.split(' '))
+        return sigs
 
-  def GetSignature(self):
-    # type: () -> str
-    sigs = self.GetSignatures()
-    if len(sigs) == 0:
-      return ""
-    return sigs[0]
+    def GetSignature(self):
+        # type: () -> str
+        sigs = self.GetSignatures()
+        if len(sigs) == 0:
+            return ""
+        return sigs[0]
 
 
 class NodeEnumKind(Message):
-  """DEPRECATED: Only used on Grok backend."""
+    """DEPRECATED: Only used on Grok backend."""
 
-  ALIAS_JOIN = 9100
-  ANNOTATION = 900
-  ARRAY = 5700
-  BIGFLOAT = 3000
-  BIGINT = 2900
-  BOOLEAN = 2000
-  CHANNEL = 6700
-  CHAR = 2100
-  CLASS = 500
-  COMMENT = 9400
-  COMMUNICATION = 3850
-  COMPLEX = 2800
-  CONSTRUCTOR = 1200
-  CONST_TYPE = 5400
-  DEF_DECL_JOIN = 9000
-  DELIMITER = 10000
-  DIAGNOSTIC = 4100
-  DIRECTORY = 4000
-  DOCUMENTATION = 9800
-  DOCUMENTATION_TAG = 9900
-  DYNAMIC_TYPE = 9300
-  ENUM = 700
-  ENUM_CONSTANT = 800
-  FIELD = 1500
-  FILE = 3900
-  FIXED_POINT = 2600
-  FLOAT = 2500
-  FORWARD_DECLARATION = 5300
-  FUNCTION = 1000
-  FUNCTION_TYPE = 10200
-  IMPORT = 8200
-  INDEX_INFO = 31337
-  INSTANCE = 4600
-  INTEGER = 2400
-  INTERFACE = 600
-  LABEL = 11600
-  LIST = 6300
-  LOCAL = 1600
-  LOST = 9600
-  MAP = 6000
-  MARKUP_ATTRIBUTE = 11300
-  MARKUP_TAG = 11200
-  MATRIX = 5800
-  METHOD = 1100
-  MODULE = 300
-  NAME = 3300
-  NAMESPACE = 100
-  NULL_TYPE = 7300
-  NUMBER = 3100
-  OBJECT = 4500
-  OPAQUE = 6500
-  OPTION_TYPE = 5500
-  PACKAGE = 200
-  PACKAGE_JOIN = 9200
-  PARAMETER = 1700
-  PARAMETRIC_TYPE = 5600
-  POINTER = 5000
-  PROPERTY = 1900
-  QUEUE = 6400
-  RATIONAL = 2700
-  REFERENCE_TYPE = 5100
-  REGEXP = 2300
-  RESTRICTION_TYPE = 10100
-  RULE = 8100
-  SEARCHABLE_IDENTIFIER = 11500
-  SEARCHABLE_NAME = 9500
-  SET = 5900
-  STRING = 2200
-  STRUCT = 400
-  SYMBOL = 3200
-  TAG_NAME = 11100
-  TARGET = 8000
-  TEMPLATE = 1400
-  TEXT = 9700
-  TEXT_MACRO = 1300
-  THREAD = 6600
-  TUPLE = 6100
-  TYPE_ALIAS = 5200
-  TYPE_DESCRIPTOR = 11400
-  TYPE_SPECIALIZATION = 7000
-  TYPE_VARIABLE = 7100
-  TYPE_VARIABLE_TYPE = 10400
-  UNION = 6200
-  UNIT_TYPE = 6900
-  UNRESOLVED_TYPE = 404
-  USAGE = 3800
-  USER_TYPE = 10300
-  VALUE = 3400
-  VARIABLE = 1800
-  VARIADIC_TYPE = 7200
-  VOID_TYPE = 6800
+    ALIAS_JOIN = 9100
+    ANNOTATION = 900
+    ARRAY = 5700
+    BIGFLOAT = 3000
+    BIGINT = 2900
+    BOOLEAN = 2000
+    CHANNEL = 6700
+    CHAR = 2100
+    CLASS = 500
+    COMMENT = 9400
+    COMMUNICATION = 3850
+    COMPLEX = 2800
+    CONSTRUCTOR = 1200
+    CONST_TYPE = 5400
+    DEF_DECL_JOIN = 9000
+    DELIMITER = 10000
+    DIAGNOSTIC = 4100
+    DIRECTORY = 4000
+    DOCUMENTATION = 9800
+    DOCUMENTATION_TAG = 9900
+    DYNAMIC_TYPE = 9300
+    ENUM = 700
+    ENUM_CONSTANT = 800
+    FIELD = 1500
+    FILE = 3900
+    FIXED_POINT = 2600
+    FLOAT = 2500
+    FORWARD_DECLARATION = 5300
+    FUNCTION = 1000
+    FUNCTION_TYPE = 10200
+    IMPORT = 8200
+    INDEX_INFO = 31337
+    INSTANCE = 4600
+    INTEGER = 2400
+    INTERFACE = 600
+    LABEL = 11600
+    LIST = 6300
+    LOCAL = 1600
+    LOST = 9600
+    MAP = 6000
+    MARKUP_ATTRIBUTE = 11300
+    MARKUP_TAG = 11200
+    MATRIX = 5800
+    METHOD = 1100
+    MODULE = 300
+    NAME = 3300
+    NAMESPACE = 100
+    NULL_TYPE = 7300
+    NUMBER = 3100
+    OBJECT = 4500
+    OPAQUE = 6500
+    OPTION_TYPE = 5500
+    PACKAGE = 200
+    PACKAGE_JOIN = 9200
+    PARAMETER = 1700
+    PARAMETRIC_TYPE = 5600
+    POINTER = 5000
+    PROPERTY = 1900
+    QUEUE = 6400
+    RATIONAL = 2700
+    REFERENCE_TYPE = 5100
+    REGEXP = 2300
+    RESTRICTION_TYPE = 10100
+    RULE = 8100
+    SEARCHABLE_IDENTIFIER = 11500
+    SEARCHABLE_NAME = 9500
+    SET = 5900
+    STRING = 2200
+    STRUCT = 400
+    SYMBOL = 3200
+    TAG_NAME = 11100
+    TARGET = 8000
+    TEMPLATE = 1400
+    TEXT = 9700
+    TEXT_MACRO = 1300
+    THREAD = 6600
+    TUPLE = 6100
+    TYPE_ALIAS = 5200
+    TYPE_DESCRIPTOR = 11400
+    TYPE_SPECIALIZATION = 7000
+    TYPE_VARIABLE = 7100
+    TYPE_VARIABLE_TYPE = 10400
+    UNION = 6200
+    UNIT_TYPE = 6900
+    UNRESOLVED_TYPE = 404
+    USAGE = 3800
+    USER_TYPE = 10300
+    VALUE = 3400
+    VARIABLE = 1800
+    VARIADIC_TYPE = 7200
+    VOID_TYPE = 6800
 
-  DESCRIPTOR = int
+    DESCRIPTOR = int
 
 
 class KytheNodeKind(Message):
-  ABS = 100
-  ABSVAR = 200
-  ANCHOR = 300
-  CONSTANT = 500
-  DEPRECATED_CALLABLE = 400
-  DOC = 550
-  FILE = 600
-  FUNCTION = 800
-  FUNCTION_CONSTRUCTOR = 810
-  FUNCTION_DESTRUCTOR = 820
-  INTERFACE = 700
-  LOOKUP = 900
-  MACRO = 1000
-  META = 1050
-  NAME = 1100
-  PACKAGE = 1200
-  RECORD = 1300
-  RECORD_CLASS = 1310
-  RECORD_STRUCT = 1320
-  RECORD_UNION = 1330
-  SUM = 1400
-  SUM_ENUM = 1410
-  SUM_ENUM_CLASS = 1420
-  TALIAS = 1500
-  TAPP = 1600
-  TBUILTIN = 1700
-  TBUILTIN_ARRAY = 1705
-  TBUILTIN_BOOLEAN = 1710
-  TBUILTIN_BYTE = 1715
-  TBUILTIN_CHAR = 1720
-  TBUILTIN_DOUBLE = 1725
-  TBUILTIN_FLOAT = 1730
-  TBUILTIN_FN = 1735
-  TBUILTIN_INT = 1740
-  TBUILTIN_LONG = 1745
-  TBUILTIN_PTR = 1750
-  TBUILTIN_SHORT = 1755
-  TBUILTIN_VOID = 1760
-  TNOMINAL = 1800
-  TSIGMA = 1850
-  UNRESOLVED_TYPE = 0
-  VARIABLE = 1900
-  VARIABLE_FIELD = 1910
-  VARIABLE_LOCAL = 1920
-  VARIABLE_LOCAL_EXCEPTION = 1940
-  VARIABLE_LOCAL_PARAMETER = 1930
-  VARIABLE_LOCAL_RESOURCE = 1950
-  VCS = 2000
+    ABS = 100
+    ABSVAR = 200
+    ANCHOR = 300
+    CONSTANT = 500
+    DEPRECATED_CALLABLE = 400
+    DOC = 550
+    FILE = 600
+    FUNCTION = 800
+    FUNCTION_CONSTRUCTOR = 810
+    FUNCTION_DESTRUCTOR = 820
+    INTERFACE = 700
+    LOOKUP = 900
+    MACRO = 1000
+    META = 1050
+    NAME = 1100
+    PACKAGE = 1200
+    RECORD = 1300
+    RECORD_CLASS = 1310
+    RECORD_STRUCT = 1320
+    RECORD_UNION = 1330
+    SUM = 1400
+    SUM_ENUM = 1410
+    SUM_ENUM_CLASS = 1420
+    TALIAS = 1500
+    TAPP = 1600
+    TBUILTIN = 1700
+    TBUILTIN_ARRAY = 1705
+    TBUILTIN_BOOLEAN = 1710
+    TBUILTIN_BYTE = 1715
+    TBUILTIN_CHAR = 1720
+    TBUILTIN_DOUBLE = 1725
+    TBUILTIN_FLOAT = 1730
+    TBUILTIN_FN = 1735
+    TBUILTIN_INT = 1740
+    TBUILTIN_LONG = 1745
+    TBUILTIN_PTR = 1750
+    TBUILTIN_SHORT = 1755
+    TBUILTIN_VOID = 1760
+    TNOMINAL = 1800
+    TSIGMA = 1850
+    UNRESOLVED_TYPE = 0
+    VARIABLE = 1900
+    VARIABLE_FIELD = 1910
+    VARIABLE_LOCAL = 1920
+    VARIABLE_LOCAL_EXCEPTION = 1940
+    VARIABLE_LOCAL_PARAMETER = 1930
+    VARIABLE_LOCAL_RESOURCE = 1950
+    VCS = 2000
 
-  DESCRIPTOR = int
+    DESCRIPTOR = int
 
 
 class Annotation(Message):
-  DESCRIPTOR = {
-      # Sent for OVERRIDE. Is an informative hover text like "Overrides
-      # net::Foo::Callback".
-      # Sent for BLAME with a semicolon separated list of Git revision, and
-      # author.
-      'content': str,
-      'file_name': str,
-      'internal_link': InternalLink,
-      'is_implicit_target': bool,
-      'kythe_xref_kind':
-          KytheNodeKind,  # Not to be confused with KytheXrefKind.
-      'range': TextRange,
-      'status': int,
-      'type': AnnotationType,
-      'url': str,
-      'xref_kind': NodeEnumKind,  # DEPRECATED
-      'xref_signature': XrefSignature,
-  }
+    DESCRIPTOR = {
+        # Sent for OVERRIDE. Is an informative hover text like "Overrides
+        # net::Foo::Callback".
+        # Sent for BLAME with a semicolon separated list of Git revision, and
+        # author.
+        'content': str,
+        'file_name': str,
+        'internal_link': InternalLink,
+        'is_implicit_target': bool,
+        'kythe_xref_kind':
+        KytheNodeKind,  # Not to be confused with KytheXrefKind.
+        'range': TextRange,
+        'status': int,
+        'type': AnnotationType,
+        'url': str,
+        'xref_kind': NodeEnumKind,  # DEPRECATED
+        'xref_signature': XrefSignature,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.content = d.get('content', "")  # type: str
-    self.file_name = d.get('file_name', "")  # type: str
-    self.internal_link = d.get('internal_link',
-                               InternalLink())  # type: InternalLink
-    self.is_implicit_target = d.get('is_implicit_target', False)  # type: bool
-    self.kythe_xref_kind = d.get('kythe_xref_kind',
-                                 KytheNodeKind.UNRESOLVED_TYPE)  # type: int
-    self.range = d.get('range', TextRange())  # type: TextRange
-    self.status = d.get('status', 0)  # type: int
-    self.type = d.get('type', AnnotationType())  # type: AnnotationType
-    self.url = d.get('url', "")  # type: str
-    self.xref_signature = d.get('xref_signature',
-                                XrefSignature())  # type: XrefSignature
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.content = d.get('content', "")  # type: str
+        self.file_name = d.get('file_name', "")  # type: str
+        self.internal_link = d.get('internal_link',
+                                   InternalLink())  # type: InternalLink
+        self.is_implicit_target = d.get('is_implicit_target',
+                                        False)  # type: bool
+        self.kythe_xref_kind = d.get('kythe_xref_kind',
+                                     KytheNodeKind.UNRESOLVED_TYPE)  # type: int
+        self.range = d.get('range', TextRange())  # type: TextRange
+        self.status = d.get('status', 0)  # type: int
+        self.type = d.get('type', AnnotationType())  # type: AnnotationType
+        self.url = d.get('url', "")  # type: str
+        self.xref_signature = d.get('xref_signature',
+                                    XrefSignature())  # type: XrefSignature
 
-  def MatchesSignature(self, signature):
-    # type: (str) -> bool
-    if self.type.id == AnnotationTypeValue.LINK_TO_DEFINITION:
-      return self.internal_link.MatchesSignature(signature)
-    if self.type.id == AnnotationTypeValue.XREF_SIGNATURE:
-      return self.xref_signature.MatchesSignature(signature)
-    return False
+    def MatchesSignature(self, signature):
+        # type: (str) -> bool
+        if self.type.id == AnnotationTypeValue.LINK_TO_DEFINITION:
+            return self.internal_link.MatchesSignature(signature)
+        if self.type.id == AnnotationTypeValue.XREF_SIGNATURE:
+            return self.xref_signature.MatchesSignature(signature)
+        return False
 
-  def HasSignature(self):
-    # type: () -> bool
-    return self.type.id == AnnotationTypeValue.LINK_TO_DEFINITION or self.type.id == AnnotationTypeValue.XREF_SIGNATURE
+    def HasSignature(self):
+        # type: () -> bool
+        return self.type.id == AnnotationTypeValue.LINK_TO_DEFINITION or \
+            self.type.id == AnnotationTypeValue.XREF_SIGNATURE
 
-  def GetSignature(self):
-    # type: () -> Optional[str]
-    if self.type.id == AnnotationTypeValue.LINK_TO_DEFINITION:
-      return self.internal_link.GetSignature()
-    if self.type.id == AnnotationTypeValue.XREF_SIGNATURE:
-      return self.xref_signature.GetSignature()
-    return None
+    def GetSignature(self):
+        # type: () -> Optional[str]
+        if self.type.id == AnnotationTypeValue.LINK_TO_DEFINITION:
+            return self.internal_link.GetSignature()
+        if self.type.id == AnnotationTypeValue.XREF_SIGNATURE:
+            return self.xref_signature.GetSignature()
+        return None
 
-  def GetSignatures(self):
-    # type: () -> List[str]
-    if self.type.id == AnnotationTypeValue.LINK_TO_DEFINITION:
-      return self.internal_link.GetSignatures()
-    if self.type.id == AnnotationTypeValue.XREF_SIGNATURE:
-      return self.xref_signature.GetSignatures()
-    return []
+    def GetSignatures(self):
+        # type: () -> List[str]
+        if self.type.id == AnnotationTypeValue.LINK_TO_DEFINITION:
+            return self.internal_link.GetSignatures()
+        if self.type.id == AnnotationTypeValue.XREF_SIGNATURE:
+            return self.xref_signature.GetSignatures()
+        return []
 
 
 class FileSpec(Message):
-  DESCRIPTOR = {
-      'name': str,
-      'package_name': str,
-      'changelist': str,  # Last known Git commit.
-  }
+    DESCRIPTOR = {
+        'name': str,
+        'package_name': str,
+        'changelist': str,  # Last known Git commit.
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.name = d.get('name', '')  # type: str
-    self.package_name = d.get('package_name', '')  # type: str
-    self.changelist = d.get('changelist', '')  # type: str
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.name = d.get('name', '')  # type: str
+        self.package_name = d.get('package_name', '')  # type: str
+        self.changelist = d.get('changelist', '')  # type: str
 
 
 class FormatType(Message):
-  CARRIAGE_RETURN = 22
-  CL_LINK = 33
-  CODESEARCH_LINK = 36
-  EXTERNAL_LINK = 31
-  INCLUDE_QUERY = 35
-  LINE = 1
-  QUERY_MATCH = 40
-  SNIPPET_QUERY_MATCH = 41
-  SYNTAX_CLASS = 8
-  SYNTAX_COMMENT = 5
-  SYNTAX_CONST = 9
-  SYNTAX_DEPRECATED = 11
-  SYNTAX_DOC_NAME = 13
-  SYNTAX_DOC_TAG = 12
-  SYNTAX_ESCAPE_SEQUENCE = 10
-  SYNTAX_KEYWORD = 3
-  SYNTAX_KEYWORD_STRONG = 15
-  SYNTAX_MACRO = 7
-  SYNTAX_MARKUP_BOLD = 51
-  SYNTAX_MARKUP_CODE = 54
-  SYNTAX_MARKUP_ENTITY = 50
-  SYNTAX_MARKUP_ITALIC = 52
-  SYNTAX_MARKUP_LINK = 53
-  SYNTAX_NUMBER = 6
-  SYNTAX_PLAIN = 2
-  SYNTAX_STRING = 4
-  SYNTAX_TASK_TAG = 14
-  TABS = 21
-  TRAILING_SPACE = 20
-  UNKNOWN_TYPE = 0
-  USER_NAME_LINK = 32
+    CARRIAGE_RETURN = 22
+    CL_LINK = 33
+    CODESEARCH_LINK = 36
+    EXTERNAL_LINK = 31
+    INCLUDE_QUERY = 35
+    LINE = 1
+    QUERY_MATCH = 40
+    SNIPPET_QUERY_MATCH = 41
+    SYNTAX_CLASS = 8
+    SYNTAX_COMMENT = 5
+    SYNTAX_CONST = 9
+    SYNTAX_DEPRECATED = 11
+    SYNTAX_DOC_NAME = 13
+    SYNTAX_DOC_TAG = 12
+    SYNTAX_ESCAPE_SEQUENCE = 10
+    SYNTAX_KEYWORD = 3
+    SYNTAX_KEYWORD_STRONG = 15
+    SYNTAX_MACRO = 7
+    SYNTAX_MARKUP_BOLD = 51
+    SYNTAX_MARKUP_CODE = 54
+    SYNTAX_MARKUP_ENTITY = 50
+    SYNTAX_MARKUP_ITALIC = 52
+    SYNTAX_MARKUP_LINK = 53
+    SYNTAX_NUMBER = 6
+    SYNTAX_PLAIN = 2
+    SYNTAX_STRING = 4
+    SYNTAX_TASK_TAG = 14
+    TABS = 21
+    TRAILING_SPACE = 20
+    UNKNOWN_TYPE = 0
+    USER_NAME_LINK = 32
 
-  DESCRIPTOR = int
+    DESCRIPTOR = int
 
 
 class FormatRange(Message):
-  DESCRIPTOR = {
-      'type': FormatType,
-      'range': TextRange,
-      'target': str,
-  }
+    DESCRIPTOR = {
+        'type': FormatType,
+        'range': TextRange,
+        'target': str,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.type = d.get('type', FormatType())  # type: FormatType
-    self.range = d.get('range', TextRange())  # type: TextRange
-    self.target = d.get('target', str())  # type: str
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.type = d.get('type', FormatType())  # type: FormatType
+        self.range = d.get('range', TextRange())  # type: TextRange
+        self.target = d.get('target', str())  # type: str
 
 
 class FileType(Message):
-  BINARY = 5
-  CODE = 1
-  DATA = 3
-  DIR = 4
-  DOC = 2
-  SYMLINK = 6
-  UNKNOWN = 0
+    BINARY = 5
+    CODE = 1
+    DATA = 3
+    DIR = 4
+    DOC = 2
+    SYMLINK = 6
+    UNKNOWN = 0
 
-  DESCRIPTOR = int
+    DESCRIPTOR = int
 
 
 class AnnotatedText(Message):
-  DESCRIPTOR = {'text': str, 'range': [FormatRange]}
+    DESCRIPTOR = {'text': str, 'range': [FormatRange]}
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.text = d.get('text', str())  # type: str
-    self.range = d.get('range', [])  # type: [FormatRange]
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.text = d.get('text', str())  # type: str
+        self.range = d.get('range', [])  # type: [FormatRange]
 
-  def Empty(self):
-    # type: () -> bool
-    return self.text == ""
+    def Empty(self):
+        # type: () -> bool
+        return self.text == ""
 
 
 class CodeBlockType(Message):
-  DESCRIPTOR = int
+    DESCRIPTOR = int
 
-  ALLOCATION = 49
-  ANONYMOUS_FUNCTION = 15
-  BUILD_ARGUMENT = 25
-  BUILD_BINARY = 21
-  BUILD_GENERATOR = 24
-  BUILD_LIBRARY = 23
-  BUILD_RULE = 20
-  BUILD_TEST = 22
-  BUILD_VARIABLE = 26
-  CLASS = 1
-  COMMENT = 13
-  DEFINE_CONST = 40
-  DEFINE_MACRO = 41
-  ENUM = 4
-  ENUM_CONSTANT = 14
-  ERROR = 0
-  FIELD = 7
-  FUNCTION = 8
-  GROUP = 51
-  INTERFACE = 2
-  JOB = 47
-  JS_ASSIGNMENT = 38
-  JS_CONST = 31
-  JS_FUNCTION_ASSIGNMENT = 39
-  JS_FUNCTION_LITERAL = 37
-  JS_GETTER = 35
-  JS_GOOG_PROVIDE = 32
-  JS_GOOG_REQUIRE = 33
-  JS_LITERAL = 36
-  JS_SETTER = 34
-  JS_VAR = 30
-  METHOD = 6
-  NAMESPACE = 11
-  PACKAGE = 17
-  PROPERTY = 12
-  RESERVED_27 = 27
-  RESERVED_28 = 28
-  RESERVED_29 = 29
-  ROOT = -1
-  SCOPE = 50
-  SERVICE = 48
-  STRUCT = 3
-  TEMPLATE = 46
-  TEST = 16
-  TYPEDEF = 10
-  UNION = 5
-  VARIABLE = 9
-  XML_TAG = 45
+    ALLOCATION = 49
+    ANONYMOUS_FUNCTION = 15
+    BUILD_ARGUMENT = 25
+    BUILD_BINARY = 21
+    BUILD_GENERATOR = 24
+    BUILD_LIBRARY = 23
+    BUILD_RULE = 20
+    BUILD_TEST = 22
+    BUILD_VARIABLE = 26
+    CLASS = 1
+    COMMENT = 13
+    DEFINE_CONST = 40
+    DEFINE_MACRO = 41
+    ENUM = 4
+    ENUM_CONSTANT = 14
+    ERROR = 0
+    FIELD = 7
+    FUNCTION = 8
+    GROUP = 51
+    INTERFACE = 2
+    JOB = 47
+    JS_ASSIGNMENT = 38
+    JS_CONST = 31
+    JS_FUNCTION_ASSIGNMENT = 39
+    JS_FUNCTION_LITERAL = 37
+    JS_GETTER = 35
+    JS_GOOG_PROVIDE = 32
+    JS_GOOG_REQUIRE = 33
+    JS_LITERAL = 36
+    JS_SETTER = 34
+    JS_VAR = 30
+    METHOD = 6
+    NAMESPACE = 11
+    PACKAGE = 17
+    PROPERTY = 12
+    RESERVED_27 = 27
+    RESERVED_28 = 28
+    RESERVED_29 = 29
+    ROOT = -1
+    SCOPE = 50
+    SERVICE = 48
+    STRUCT = 3
+    TEMPLATE = 46
+    TEST = 16
+    TYPEDEF = 10
+    UNION = 5
+    VARIABLE = 9
+    XML_TAG = 45
 
 
 class Modifiers(Message):
-  DESCRIPTOR = {
-      '_global': bool,
-      '_thread_local': bool,
-      'abstract': bool,
-      'anonymous': bool,
-      'autogenerated': bool,
-      'close_delimiter': bool,
-      'constexpr_': bool,
-      'declaration': bool,
-      'definition': bool,
-      'deprecated': bool,
-      'discrete': bool,
-      'dynamically_scoped': bool,
-      'exported': bool,
-      'file_scoped': bool,
-      'foreign': bool,
-      'getter': bool,
-      'has_figment': bool,
-      'immutable': bool,
-      'implicit': bool,
-      'inferred': bool,
-      'is_figment': bool,
-      'join_node': bool,
-      'library_scoped': bool,
-      'namespace_scoped': bool,
-      'nonescaped': bool,
-      'open_delimiter': bool,
-      'operator': bool,
-      'optional': bool,
-      'package_scoped': bool,
-      'parametric': bool,
-      'predeclared': bool,
-      'private': bool,
-      'protected': bool,
-      'public': bool,
-      'receiver': bool,
-      'register': bool,
-      'renamed': bool,
-      'repeated': bool,
-      'setter': bool,
-      'shadowing': bool,
-      'signed': bool,
-      'static': bool,
-      'strict_math': bool,
-      'synchronized': bool,
-      'terminal': bool,
-      'transient': bool,
-      'unsigned': bool,
-      'virtual': bool,
-      'volatile': bool,
-      'whitelisted': bool,
-  }
+    DESCRIPTOR = {
+        '_global': bool,
+        '_thread_local': bool,
+        'abstract': bool,
+        'anonymous': bool,
+        'autogenerated': bool,
+        'close_delimiter': bool,
+        'constexpr_': bool,
+        'declaration': bool,
+        'definition': bool,
+        'deprecated': bool,
+        'discrete': bool,
+        'dynamically_scoped': bool,
+        'exported': bool,
+        'file_scoped': bool,
+        'foreign': bool,
+        'getter': bool,
+        'has_figment': bool,
+        'immutable': bool,
+        'implicit': bool,
+        'inferred': bool,
+        'is_figment': bool,
+        'join_node': bool,
+        'library_scoped': bool,
+        'namespace_scoped': bool,
+        'nonescaped': bool,
+        'open_delimiter': bool,
+        'operator': bool,
+        'optional': bool,
+        'package_scoped': bool,
+        'parametric': bool,
+        'predeclared': bool,
+        'private': bool,
+        'protected': bool,
+        'public': bool,
+        'receiver': bool,
+        'register': bool,
+        'renamed': bool,
+        'repeated': bool,
+        'setter': bool,
+        'shadowing': bool,
+        'signed': bool,
+        'static': bool,
+        'strict_math': bool,
+        'synchronized': bool,
+        'terminal': bool,
+        'transient': bool,
+        'unsigned': bool,
+        'virtual': bool,
+        'volatile': bool,
+        'whitelisted': bool,
+    }
 
-  def __init__(self, **kwargs):
-    self.__dict__ = kwargs
+    def __init__(self, **kwargs):
+        self.__dict__ = kwargs
 
 
 class CodeBlock(Message):
-  DESCRIPTOR = {
-      'child': [Message.PARENT_TYPE],
-      'modifiers': Modifiers,
-      'name': str,  # Unadorned name.
-      'name_prefix': str,  # Class qualifiers. I.e. For a function named
-      # net::Foo::Bar, where net is a namespace, name="Bar",
-      # name_prefix="Foo::".
-      'signature': str,  # Valid if .type == FUNCTION. The signature
-      # includes the function parameters excluding the
-      # function name. This is not a CodeSearch ticket.
-      'text_range': TextRange,
-      'type': CodeBlockType,
-  }
+    DESCRIPTOR = {
+        'child': [Message.PARENT_TYPE],
+        'modifiers': Modifiers,
+        'name': str,  # Unadorned name.
+        'name_prefix': str,  # Class qualifiers. I.e. For a function named
+        # net::Foo::Bar, where net is a namespace, name="Bar",
+        # name_prefix="Foo::".
+        'signature': str,  # Valid if .type == FUNCTION. The signature
+        # includes the function parameters excluding the
+        # function name. This is not a CodeSearch ticket.
+        'text_range': TextRange,
+        'type': CodeBlockType,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.child = d.get('child', [])  # type: [CodeBlock]
-    self.modifiers = d.get('modifiers', Modifiers())  # type: Modifiers
-    self.name = d.get('name', str())  # type: str
-    self.name_prefix = d.get('name_prefix', str())  # type: str
-    self.signature = d.get('signature', str())  # type: str
-    self.text_range = d.get('text_range', TextRange())  # type: TextRange
-    self.type = d.get('type', 0)  # type: int
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.child = d.get('child', [])  # type: [CodeBlock]
+        self.modifiers = d.get('modifiers', Modifiers())  # type: Modifiers
+        self.name = d.get('name', str())  # type: str
+        self.name_prefix = d.get('name_prefix', str())  # type: str
+        self.signature = d.get('signature', str())  # type: str
+        self.text_range = d.get('text_range', TextRange())  # type: TextRange
+        self.type = d.get('type', 0)  # type: int
 
-  def Find(self, name="", type=CodeBlockType.ROOT):
-    """Find the self or child CodeBlock that matches the name and type.
+    def Find(self, name="", type=CodeBlockType.ROOT):
+        """Find the self or child CodeBlock that matches the name and type.
 
       The special *name* value of "*" matches all names.
       """
 
-    if (self.name == name or name == "*") and self.type == type:
-      return self
-    for c in self.child:
-      n = c.Find(name, type)
-      if n is not None:
-        return n
-    return None
+        if (self.name == name or name == "*") and self.type == type:
+            return self
+        for c in self.child:
+            n = c.Find(name, type)
+            if n is not None:
+                return n
+        return None
 
 
 class GobInfo(Message):
-  DESCRIPTOR = {
-      'commit': str,  # Git commit
-      'path': str,  # Path relative to repository
-      'repo': str,  # Repository path. Chromium's is "chromium/chromium/src"
-  }
+    DESCRIPTOR = {
+        'commit': str,  # Git commit
+        'path': str,  # Path relative to repository
+        'repo': str,  # Repository path. Chromium's is "chromium/chromium/src"
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.commit = d.get('commit', str())  # type: str
-    self.path = d.get('path', str())  # type: str
-    self.repo = d.get('repo', str())  # type: str
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.commit = d.get('commit', str())  # type: str
+        self.path = d.get('path', str())  # type: str
+        self.repo = d.get('repo', str())  # type: str
 
 
 class FileInfo(Message):
-  DESCRIPTOR = {
-      'actual_name': str,
-      'changelist_num': str,  # Git commit hash for indexed ToT.
-      'codeblock': [CodeBlock],
-      'content': AnnotatedText,
-      'converted_content': AnnotatedText,
-      'converted_lines': int,
-      'fold_ranges': [TextRange],
-      'generated': bool,  # Generated file?
-      'generated_from': [str],
-      'gob_info': GobInfo,
-      'html_text': str,
-      'language': str,  # "c++" etc.
-      'license_path': str,
-      'license_type': str,
-      'lines': int,
-      'md5': str,
-      'mime_type': str,
-      'name': str,
-      'package_name': str,
-      'revision_num': str,  # DEPRECATED
-      'size': int,
-      'type': FileType,
-  }
+    DESCRIPTOR = {
+        'actual_name': str,
+        'changelist_num': str,  # Git commit hash for indexed ToT.
+        'codeblock': [CodeBlock],
+        'content': AnnotatedText,
+        'converted_content': AnnotatedText,
+        'converted_lines': int,
+        'fold_ranges': [TextRange],
+        'generated': bool,  # Generated file?
+        'generated_from': [str],
+        'gob_info': GobInfo,
+        'html_text': str,
+        'language': str,  # "c++" etc.
+        'license_path': str,
+        'license_type': str,
+        'lines': int,
+        'md5': str,
+        'mime_type': str,
+        'name': str,
+        'package_name': str,
+        'revision_num': str,  # DEPRECATED
+        'size': int,
+        'type': FileType,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.actual_name = d.get('actual_name', str())  # type: str
-    self.changelist_num = d.get('changelist_num', str())  # type: str
-    self.codeblock = d.get('codeblock', [])  # type: List[CodeBlock]
-    self.content = d.get('content', AnnotatedText())  # type: AnnotatedText
-    self.converted_content = d.get('converted_content',
-                                   AnnotatedText())  # type: AnnotatedText
-    self.converted_lines = d.get('converted_lines', int())  # type: int
-    self.fold_ranges = d.get('fold_ranges', [])  # type: List[TextRange]
-    self.generated = d.get('generated', bool())  # type: bool
-    self.generated_from = d.get('generated_from', [])  # type: List[str]
-    self.gob_info = d.get('gob_info', GobInfo())  # type: GobInfo
-    self.html_text = d.get('html_text', str())  # type: str
-    self.language = d.get('language', str())  # type: str
-    self.license_path = d.get('license_path', str())  # type: str
-    self.license_type = d.get('license_type', str())  # type: str
-    self.lines = d.get('lines', int())  # type: int
-    self.md5 = d.get('md5', str())  # type: str
-    self.mime_type = d.get('mime_type', str())  # type: str
-    self.name = d.get('name', str())  # type: str
-    self.package_name = d.get('package_name', str())  # type: str
-    self.size = d.get('size', int())  # type: int
-    self.type = d.get('type', FileType())  # type: FileType
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.actual_name = d.get('actual_name', str())  # type: str
+        self.changelist_num = d.get('changelist_num', str())  # type: str
+        self.codeblock = d.get('codeblock', [])  # type: List[CodeBlock]
+        self.content = d.get('content', AnnotatedText())  # type: AnnotatedText
+        self.converted_content = d.get('converted_content',
+                                       AnnotatedText())  # type: AnnotatedText
+        self.converted_lines = d.get('converted_lines', int())  # type: int
+        self.fold_ranges = d.get('fold_ranges', [])  # type: List[TextRange]
+        self.generated = d.get('generated', bool())  # type: bool
+        self.generated_from = d.get('generated_from', [])  # type: List[str]
+        self.gob_info = d.get('gob_info', GobInfo())  # type: GobInfo
+        self.html_text = d.get('html_text', str())  # type: str
+        self.language = d.get('language', str())  # type: str
+        self.license_path = d.get('license_path', str())  # type: str
+        self.license_type = d.get('license_type', str())  # type: str
+        self.lines = d.get('lines', int())  # type: int
+        self.md5 = d.get('md5', str())  # type: str
+        self.mime_type = d.get('mime_type', str())  # type: str
+        self.name = d.get('name', str())  # type: str
+        self.package_name = d.get('package_name', str())  # type: str
+        self.size = d.get('size', int())  # type: int
+        self.type = d.get('type', FileType())  # type: FileType
 
 
 class FileInfoResponse(Message):
-  DESCRIPTOR = {
-      'announcement': str,
-      'error_message': str,
-      'file_info': FileInfo,
-      'return_code': int,
-  }
+    DESCRIPTOR = {
+        'announcement': str,
+        'error_message': str,
+        'file_info': FileInfo,
+        'return_code': int,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.announcement = d.get('announcement', str())  # type: str
-    self.error_message = d.get('error_message', str())  # type: str
-    self.file_info = d.get('file_info', FileInfo())  # type: FileInfo
-    self.return_code = d.get('return_code', int())  # type: int
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.announcement = d.get('announcement', str())  # type: str
+        self.error_message = d.get('error_message', str())  # type: str
+        self.file_info = d.get('file_info', FileInfo())  # type: FileInfo
+        self.return_code = d.get('return_code', int())  # type: int
 
 
 class FileInfoRequest(Message):
-  DESCRIPTOR = {
-      'file_spec': FileSpec.__class__,
-      'fetch_html_content': bool,
-      'fetch_outline': bool,
-      'fetch_folding': bool,
-      'fetch_generated_from': bool,
-  }
+    DESCRIPTOR = {
+        'file_spec': FileSpec.__class__,
+        'fetch_html_content': bool,
+        'fetch_outline': bool,
+        'fetch_folding': bool,
+        'fetch_generated_from': bool,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.file_spec = d.get('file_spec', FileSpec())  # type: FileSpec
-    self.fetch_html_content = d.get('fetch_html_content', bool())  # type: bool
-    self.fetch_outline = d.get('fetch_outline', bool())  # type: bool
-    self.fetch_folding = d.get('fetch_folding', bool())  # type: bool
-    self.fetch_generated_from = d.get('fetch_generated_from',
-                                      bool())  # type: bool
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.file_spec = d.get('file_spec', FileSpec())  # type: FileSpec
+        self.fetch_html_content = d.get('fetch_html_content',
+                                        bool())  # type: bool
+        self.fetch_outline = d.get('fetch_outline', bool())  # type: bool
+        self.fetch_folding = d.get('fetch_folding', bool())  # type: bool
+        self.fetch_generated_from = d.get('fetch_generated_from',
+                                          bool())  # type: bool
 
 
 class AnnotationResponse(Message):
-  DESCRIPTOR = {
-      'annotation': [Annotation],
-      'file': str,  # Not populated
-      'max_findings_reached': bool,
-      'return_code': int,
-  }
+    DESCRIPTOR = {
+        'annotation': [Annotation],
+        'file': str,  # Not populated
+        'max_findings_reached': bool,
+        'return_code': int,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.annotation = d.get('annotation', [])  # type: List[Annotation]
-    self.file = d.get('file', str())  # type: str
-    self.max_findings_reached = d.get('max_findings_reached',
-                                      bool())  # type: bool
-    self.return_code = d.get('return_code', int())  # type: int
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.annotation = d.get('annotation', [])  # type: List[Annotation]
+        self.file = d.get('file', str())  # type: str
+        self.max_findings_reached = d.get('max_findings_reached',
+                                          bool())  # type: bool
+        self.return_code = d.get('return_code', int())  # type: int
 
 
 class AnnotationRequest(Message):
-  DESCRIPTOR = {
-      'file_spec': FileSpec,
-      'type': [AnnotationType],
-      'md5': str,
-  }
+    DESCRIPTOR = {
+        'file_spec': FileSpec,
+        'type': [AnnotationType],
+        'md5': str,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.file_spec = d.get('file_spec', FileSpec())  # type: FileSpec
-    self.type = d.get('type', [])  # type: List[AnnotationType]
-    self.md5 = d.get('md5', str())  # type: str
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.file_spec = d.get('file_spec', FileSpec())  # type: FileSpec
+        self.type = d.get('type', [])  # type: List[AnnotationType]
+        self.md5 = d.get('md5', str())  # type: str
 
-  def AsQueryString(self):
-    # type: () -> List[Tuple[str,str]]
-    qs = Message.AsQueryString(self)
-    if not self.md5:
-      idx = qs.index(('file_spec', 'e'))
-      qs.insert(idx + 1, ('md5', ''))
-    return qs
+    def AsQueryString(self):
+        # type: () -> List[Tuple[str,str]]
+        qs = Message.AsQueryString(self)
+        if not self.md5:
+            idx = qs.index(('file_spec', 'e'))
+            qs.insert(idx + 1, ('md5', ''))
+        return qs
 
 
 class MatchReason(Message):
-  DESCRIPTOR = {
-      'blame': bool,
-      'content': bool,
-      'filename': bool,
-      'filename_lineno': bool,
-      'scoped_symbol': bool,
-  }
+    DESCRIPTOR = {
+        'blame': bool,
+        'content': bool,
+        'filename': bool,
+        'filename_lineno': bool,
+        'scoped_symbol': bool,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.blame = d.get('blame', bool())  # type: bool
-    self.content = d.get('content', bool())  # type: bool
-    self.filename = d.get('filename', bool())  # type: bool
-    self.filename_lineno = d.get('filename_lineno', bool())  # type: bool
-    self.scoped_symbol = d.get('scoped_symbol', bool())  # type: bool
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.blame = d.get('blame', bool())  # type: bool
+        self.content = d.get('content', bool())  # type: bool
+        self.filename = d.get('filename', bool())  # type: bool
+        self.filename_lineno = d.get('filename_lineno', bool())  # type: bool
+        self.scoped_symbol = d.get('scoped_symbol', bool())  # type: bool
 
 
 class Snippet(Message):
-  DESCRIPTOR = {
-      'first_line_number': int,
-      'match_reason': MatchReason,
-      'scope': str,
-      'text': AnnotatedText,
-  }
+    DESCRIPTOR = {
+        'first_line_number': int,
+        'match_reason': MatchReason,
+        'scope': str,
+        'text': AnnotatedText,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.first_line_number = d.get('first_line_number', int())  # type: int
-    self.match_reason = d.get('match_reason',
-                              MatchReason())  # type: MatchReason
-    self.scope = d.get('scope', str())  # type: str
-    self.text = d.get('text', AnnotatedText())  # type: AnnotatedText
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.first_line_number = d.get('first_line_number', int())  # type: int
+        self.match_reason = d.get('match_reason',
+                                  MatchReason())  # type: MatchReason
+        self.scope = d.get('scope', str())  # type: str
+        self.text = d.get('text', AnnotatedText())  # type: AnnotatedText
 
-  def Empty(self):
-    # type: () -> bool
-    return self.first_line_number == 0 or self.text.Empty()
+    def Empty(self):
+        # type: () -> bool
+        return self.first_line_number == 0 or self.text.Empty()
 
 
 class Node(Message):
-  DESCRIPTOR = {
-      # Take this example snippet:
-      #
-      # 03  void Foo(int a, int b) {
-      # 04    Bar();
-      # 05  }
-      #
-      # If this is a call graph node for Bar(), then call_scope_range would
-      # cover "Foo" on line 3 (i.e. call_scope_range { start_line: 3,
-      # start_column: 6, end_line: 3, end_column: 8 })
-      #
-      # call_site_range would cover the function call on line 4. I.e
-      # call_site_range { start_line: 4, start_column: 3, end_line: 4,
-      # end_column: 7 }
-      'call_scope_range': TextRange,  # Range defining calling function name.
-      'call_site_range': TextRange,  # Range defining call site.
-      'children': [Message.PARENT_TYPE],  # Nodes corresponding to callsites of 
-      'display_name': str,  # Deprecated.
-      'edge_kind': str,  # Deprecated.
-      'file_path': str,
-      'identifier': str,
-      'node_kind': KytheNodeKind,
-      'override': bool,
-      'package_name': str,
-      'params': [str],  # For FUNCTION nodes, list of parameter names.
-      # No type information present.
-      'signature':
-          str,  # Signature for call scope. I.e. thing at call_scope_range.
-      'snippet': Snippet,
-      'snippet_file_path': str,
-      'snippet_package_name': str,
-  }
+    DESCRIPTOR = {
+        # Take this example snippet:
+        #
+        # 03  void Foo(int a, int b) {
+        # 04    Bar();
+        # 05  }
+        #
+        # If this is a call graph node for Bar(), then call_scope_range would
+        # cover "Foo" on line 3 (i.e. call_scope_range { start_line: 3,
+        # start_column: 6, end_line: 3, end_column: 8 })
+        #
+        # call_site_range would cover the function call on line 4. I.e
+        # call_site_range { start_line: 4, start_column: 3, end_line: 4,
+        # end_column: 7 }
+        'call_scope_range': TextRange,  # Range defining calling function name.
+        'call_site_range': TextRange,  # Range defining call site.
+        'children': [Message.PARENT_TYPE],  # Nodes corresponding to callsites
+        'display_name': str,  # Deprecated.
+        'edge_kind': str,  # Deprecated.
+        'file_path': str,
+        'identifier': str,
+        'node_kind': KytheNodeKind,
+        'override': bool,
+        'package_name': str,
+        'params': [str],  # For FUNCTION nodes, list of parameter names.
+        # No type information present.
+        'signature':
+        str,  # Signature for call scope. I.e. thing at call_scope_range.
+        'snippet': Snippet,
+        'snippet_file_path': str,
+        'snippet_package_name': str,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.call_scope_range = d.get('call_scope_range',
-                                  TextRange())  # type: TextRange
-    self.call_site_range = d.get('call_site_range',
-                                 TextRange())  # type: TextRange
-    self.children = d.get('children', [])  # type: [Node]
-    self.display_name = d.get('display_name', str())  # type: str
-    self.edge_kind = d.get('edge_kind', str())  # type: str
-    self.file_path = d.get('file_path', str())  # type: str
-    self.identifier = d.get('identifier', str())  # type: str
-    self.node_kind = d.get('node_kind', int)  # type: int
-    self.override = d.get('override', bool())  # type: bool
-    self.package_name = d.get('package_name', str())  # type: str
-    self.params = d.get('params', [])  # type: [str]
-    self.signature = d.get('signature', str())  # type: str
-    self.snippet = d.get('snippet', Snippet())  # type: Snippet
-    self.snippet_file_path = d.get('snippet_file_path', str())  # type: str
-    self.snippet_package_name = d.get('snippet_package_name',
-                                      str())  # type: str
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.call_scope_range = d.get('call_scope_range',
+                                      TextRange())  # type: TextRange
+        self.call_site_range = d.get('call_site_range',
+                                     TextRange())  # type: TextRange
+        self.children = d.get('children', [])  # type: [Node]
+        self.display_name = d.get('display_name', str())  # type: str
+        self.edge_kind = d.get('edge_kind', str())  # type: str
+        self.file_path = d.get('file_path', str())  # type: str
+        self.identifier = d.get('identifier', str())  # type: str
+        self.node_kind = d.get('node_kind', int)  # type: int
+        self.override = d.get('override', bool())  # type: bool
+        self.package_name = d.get('package_name', str())  # type: str
+        self.params = d.get('params', [])  # type: [str]
+        self.signature = d.get('signature', str())  # type: str
+        self.snippet = d.get('snippet', Snippet())  # type: Snippet
+        self.snippet_file_path = d.get('snippet_file_path', str())  # type: str
+        self.snippet_package_name = d.get('snippet_package_name',
+                                          str())  # type: str
 
 
 class CallGraphResponse(Message):
-  DESCRIPTOR = {
-      'debug_message': str,
-      'estimated_total_number_results': int,
-      'is_call_graph': bool,
-      'is_from_kythe': bool,
-      'kythe_next_page_token': str,
-      'node': Node,
-      'results_offset': int,
-      'return_code': int,
-  }
+    DESCRIPTOR = {
+        'debug_message': str,
+        'estimated_total_number_results': int,
+        'is_call_graph': bool,
+        'is_from_kythe': bool,
+        'kythe_next_page_token': str,
+        'node': Node,
+        'results_offset': int,
+        'return_code': int,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.debug_message = d.get('debug_message', str())  # type: str
-    self.estimated_total_number_results = d.get(
-        'estimated_total_number_results', int())  # type: int
-    self.is_call_graph = d.get('is_call_graph', bool())  # type: bool
-    self.is_from_kythe = d.get('is_from_kythe', bool())  # type: bool
-    self.kythe_next_page_token = d.get('kythe_next_page_token',
-                                       str())  # type: str
-    self.node = d.get('node', Node())  # type: Node
-    self.results_offset = d.get('results_offset', int())  # type: int
-    self.return_code = d.get('return_code', int())  # type: int
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.debug_message = d.get('debug_message', str())  # type: str
+        self.estimated_total_number_results = d.get(
+            'estimated_total_number_results', int())  # type: int
+        self.is_call_graph = d.get('is_call_graph', bool())  # type: bool
+        self.is_from_kythe = d.get('is_from_kythe', bool())  # type: bool
+        self.kythe_next_page_token = d.get('kythe_next_page_token',
+                                           str())  # type: str
+        self.node = d.get('node', Node())  # type: Node
+        self.results_offset = d.get('results_offset', int())  # type: int
+        self.return_code = d.get('return_code', int())  # type: int
 
 
 class CallGraphRequest(Message):
-  DESCRIPTOR = {
-      'file_spec': FileSpec,
-      'max_num_results': int,
-      'signature': str,
-  }
+    DESCRIPTOR = {
+        'file_spec': FileSpec,
+        'max_num_results': int,
+        'signature': str,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.file_spec = d.get('file_spec', FileSpec())  # type: FileSpec
-    self.max_num_results = d.get('max_num_results', 100)  # type: int
-    self.signature = d.get('signature', str())  # type: str
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.file_spec = d.get('file_spec', FileSpec())  # type: FileSpec
+        self.max_num_results = d.get('max_num_results', 100)  # type: int
+        self.signature = d.get('signature', str())  # type: str
 
 
 class EdgeEnumKind(Message):
-  """Types of edge.
+    """Types of edge.
 
   DEPRECATED: Only used by Grok backend.
   """
 
-  DESCRIPTOR = int
+    DESCRIPTOR = int
 
-  ALLOWED_ACCESS_TO = 4500
-  ANNOTATED_WITH = 5000
-  ANNOTATION_OF = 5100
-  BASE_TYPE = 1300
-  BELONGS_TO_NAMESPACE = 7200
-  BELONGS_TO_PACKAGE = 6900
-  CALL = 2200
-  CALLED_AT = 2300
-  CALLGRAPH_FROM = 4700
-  CALLGRAPH_TO = 4600
-  CAPTURED_BY = 1200
-  CAPTURES = 1100
-  CATCHES = 6400
-  CAUGHT_BY = 6500
-  CHANNEL_USED_BY = 2351
-  CHILD = 5300
-  COMMENT_IN_FILE = 7400
-  COMPOSING_TYPE = 1400
-  CONSUMED_BY = 4100
-  CONTAINS_COMMENT = 7500
-  CONTAINS_DECLARATION = 5800
-  CONTAINS_USAGE = 6000
-  DECLARATION_IN_FILE = 5900
-  DECLARATION_OF = 3200
-  DECLARED_BY = 400
-  DECLARES = 300
-  DEFINITION_OF = 3400
-  DIAGNOSTIC_OF = 5400
-  DIRECTLY_INHERITED_BY = 1060
-  DIRECTLY_INHERITS = 1050
-  DIRECTLY_OVERRIDDEN_BY = 860
-  DIRECTLY_OVERRIDES = 850
-  DOCUMENTED_WITH = 7700
-  DOCUMENTS = 7600
-  ENCLOSED_USAGE = 4900
-  EXTENDED_BY = 200
-  EXTENDS = 100
-  GENERATED_BY = 3100
-  GENERATES = 3000
-  GENERATES_NAME = 3150
-  HAS_DECLARATION = 3300
-  HAS_DEFINITION = 3500
-  HAS_DIAGNOSTIC = 5500
-  HAS_FIGMENT = 9200
-  HAS_IDENTIFIER = 9400
-  HAS_INPUT = 4000
-  HAS_OUTPUT = 4200
-  HAS_PROPERTY = 2800
-  HAS_SELECTION = 10900
-  HAS_TYPE = 1800
-  IMPLEMENTED_BY = 600
-  IMPLEMENTS = 500
-  INHERITED_BY = 1000
-  INHERITS = 900
-  INITIALIZED_WITH = 9100
-  INITIALIZES = 9000
-  INJECTED_AT = 10500
-  INJECTS = 10400
-  INSTANTIATED_AT = 2500
-  INSTANTIATION = 2400
-  IS_FIGMENT_OF = 9300
-  IS_IDENTIFIER_OF = 9500
-  IS_TYPE_OF = 1900
-  KEY_METHOD = 3600
-  KEY_METHOD_OF = 3700
-  MEMBER_SELECTED_AT = 10700
-  NAMESPACE_CONTAINS = 7300
-  NAME_GENERATED_BY = 3160
-  OUTLINE_CHILD = 5700
-  OUTLINE_PARENT = 5600
-  OVERRIDDEN_BY = 800
-  OVERRIDES = 700
-  PACKAGE_CONTAINS = 6800
-  PARAMETER_TYPE = 8800
-  PARAMETER_TYPE_OF = 8900
-  PARENT = 5200
-  PRODUCED_BY = 4300
-  PROPERTY_OF = 2900
-  RECEIVES_FROM = 2353
-  REFERENCE = 2600
-  REFERENCED_AT = 2700
-  REQUIRED_BY = 3900
-  REQUIRES = 3800
-  RESTRICTED_TO = 4400
-  RETURNED_BY = 2100
-  RETURN_TYPE = 2000
-  SELECTED_FROM = 10800
-  SELECTS_MEMBER_OF = 10600
-  SENDS_TO = 2352
-  SPECIALIZATION_OF = 1600
-  SPECIALIZED_BY = 1700
-  THROWGRAPH_FROM = 6700
-  THROWGRAPH_TO = 6600
-  THROWN_BY = 6300
-  THROWS = 6200
-  TREE_CHILD = 7900
-  TREE_PARENT = 7800
-  TYPE_PARAMETER = 1500
-  TYPE_PARAMETER_OF = 1550
-  USAGE_CONTEXT = 4800
-  USAGE_IN_FILE = 6100
-  USES_CHANNEL = 2350
-  USES_VARIABLE = 7000
-  VARIABLE_USED_IN = 7100
-  XLANG_PROVIDES = 8600
-  XLANG_PROVIDES_NAME = 8400
-  XLANG_USES = 8700
-  XLANG_USES_NAME = 8500
+    ALLOWED_ACCESS_TO = 4500
+    ANNOTATED_WITH = 5000
+    ANNOTATION_OF = 5100
+    BASE_TYPE = 1300
+    BELONGS_TO_NAMESPACE = 7200
+    BELONGS_TO_PACKAGE = 6900
+    CALL = 2200
+    CALLED_AT = 2300
+    CALLGRAPH_FROM = 4700
+    CALLGRAPH_TO = 4600
+    CAPTURED_BY = 1200
+    CAPTURES = 1100
+    CATCHES = 6400
+    CAUGHT_BY = 6500
+    CHANNEL_USED_BY = 2351
+    CHILD = 5300
+    COMMENT_IN_FILE = 7400
+    COMPOSING_TYPE = 1400
+    CONSUMED_BY = 4100
+    CONTAINS_COMMENT = 7500
+    CONTAINS_DECLARATION = 5800
+    CONTAINS_USAGE = 6000
+    DECLARATION_IN_FILE = 5900
+    DECLARATION_OF = 3200
+    DECLARED_BY = 400
+    DECLARES = 300
+    DEFINITION_OF = 3400
+    DIAGNOSTIC_OF = 5400
+    DIRECTLY_INHERITED_BY = 1060
+    DIRECTLY_INHERITS = 1050
+    DIRECTLY_OVERRIDDEN_BY = 860
+    DIRECTLY_OVERRIDES = 850
+    DOCUMENTED_WITH = 7700
+    DOCUMENTS = 7600
+    ENCLOSED_USAGE = 4900
+    EXTENDED_BY = 200
+    EXTENDS = 100
+    GENERATED_BY = 3100
+    GENERATES = 3000
+    GENERATES_NAME = 3150
+    HAS_DECLARATION = 3300
+    HAS_DEFINITION = 3500
+    HAS_DIAGNOSTIC = 5500
+    HAS_FIGMENT = 9200
+    HAS_IDENTIFIER = 9400
+    HAS_INPUT = 4000
+    HAS_OUTPUT = 4200
+    HAS_PROPERTY = 2800
+    HAS_SELECTION = 10900
+    HAS_TYPE = 1800
+    IMPLEMENTED_BY = 600
+    IMPLEMENTS = 500
+    INHERITED_BY = 1000
+    INHERITS = 900
+    INITIALIZED_WITH = 9100
+    INITIALIZES = 9000
+    INJECTED_AT = 10500
+    INJECTS = 10400
+    INSTANTIATED_AT = 2500
+    INSTANTIATION = 2400
+    IS_FIGMENT_OF = 9300
+    IS_IDENTIFIER_OF = 9500
+    IS_TYPE_OF = 1900
+    KEY_METHOD = 3600
+    KEY_METHOD_OF = 3700
+    MEMBER_SELECTED_AT = 10700
+    NAMESPACE_CONTAINS = 7300
+    NAME_GENERATED_BY = 3160
+    OUTLINE_CHILD = 5700
+    OUTLINE_PARENT = 5600
+    OVERRIDDEN_BY = 800
+    OVERRIDES = 700
+    PACKAGE_CONTAINS = 6800
+    PARAMETER_TYPE = 8800
+    PARAMETER_TYPE_OF = 8900
+    PARENT = 5200
+    PRODUCED_BY = 4300
+    PROPERTY_OF = 2900
+    RECEIVES_FROM = 2353
+    REFERENCE = 2600
+    REFERENCED_AT = 2700
+    REQUIRED_BY = 3900
+    REQUIRES = 3800
+    RESTRICTED_TO = 4400
+    RETURNED_BY = 2100
+    RETURN_TYPE = 2000
+    SELECTED_FROM = 10800
+    SELECTS_MEMBER_OF = 10600
+    SENDS_TO = 2352
+    SPECIALIZATION_OF = 1600
+    SPECIALIZED_BY = 1700
+    THROWGRAPH_FROM = 6700
+    THROWGRAPH_TO = 6600
+    THROWN_BY = 6300
+    THROWS = 6200
+    TREE_CHILD = 7900
+    TREE_PARENT = 7800
+    TYPE_PARAMETER = 1500
+    TYPE_PARAMETER_OF = 1550
+    USAGE_CONTEXT = 4800
+    USAGE_IN_FILE = 6100
+    USES_CHANNEL = 2350
+    USES_VARIABLE = 7000
+    VARIABLE_USED_IN = 7100
+    XLANG_PROVIDES = 8600
+    XLANG_PROVIDES_NAME = 8400
+    XLANG_USES = 8700
+    XLANG_USES_NAME = 8500
 
 
 class KytheXrefKind(Message):
-  DESCRIPTOR = int
+    DESCRIPTOR = int
 
-  DEFINITION = 1
-  DECLARATION = 2
-  REFERENCE = 3
+    DEFINITION = 1
+    DECLARATION = 2
+    REFERENCE = 3
 
-  OVERRIDES = 4
-  OVERRIDDEN_BY = 5
-  EXTENDS = 6
-  EXTENDED_BY = 7
+    OVERRIDES = 4
+    OVERRIDDEN_BY = 5
+    EXTENDS = 6
+    EXTENDED_BY = 7
 
-  INSTANTIATION = 8
+    INSTANTIATION = 8
 
-  GENERATES = 10
-  GENERATED_BY = 11
+    GENERATES = 10
+    GENERATED_BY = 11
 
-  ANNOTATES = 12
-  ANNOTATED_BY = 13
+    ANNOTATES = 12
+    ANNOTATED_BY = 13
 
-  # These are manual additions for extending the xref lookup features.
-  CALLS = -100  # Provided for symmetry. Not implemented.
-  CALLED_BY = -101
+    # These are manual additions for extending the xref lookup features.
+    CALLS = -100  # Provided for symmetry. Not implemented.
+    CALLED_BY = -101
 
 
 class XrefTypeCount(Message):
-  DESCRIPTOR = {
-      'count': int,
-      'type': str,
-      'type_id': KytheXrefKind,
-  }
+    DESCRIPTOR = {
+        'count': int,
+        'type': str,
+        'type_id': KytheXrefKind,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.count = d.get('count', int())  # type: int
-    self.type = d.get('type', str())  # type: str
-    self.type_id = d.get('type_id', KytheXrefKind())  # type: KytheXrefKind
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.count = d.get('count', int())  # type: int
+        self.type = d.get('type', str())  # type: str
+        self.type_id = d.get('type_id', KytheXrefKind())  # type: KytheXrefKind
 
 
 class XrefSingleMatch(Message):
-  DESCRIPTOR = {
-      'line_number': int,
-      'line_text': str,
-      'type': str,
-      'type_id': KytheXrefKind,
-      'node_type': NodeEnumKind,  # DEPRECATED
-      'grok_modifiers': Modifiers,  # DEPRECATED
-      'signature': str,
-  }
+    DESCRIPTOR = {
+        'line_number': int,
+        'line_text': str,
+        'type': str,
+        'type_id': KytheXrefKind,
+        'node_type': NodeEnumKind,  # DEPRECATED
+        'grok_modifiers': Modifiers,  # DEPRECATED
+        'signature': str,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.line_number = d.get('line_number', int())  # type: int
-    self.line_text = d.get('line_text', str())  # type: str
-    self.type = d.get('type', str())  # type: str
-    self.type_id = d.get('type_id', KytheXrefKind())  # type: KytheXrefKind
-    self.signature = d.get('signature', str())  # type: str
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.line_number = d.get('line_number', int())  # type: int
+        self.line_text = d.get('line_text', str())  # type: str
+        self.type = d.get('type', str())  # type: str
+        self.type_id = d.get('type_id', KytheXrefKind())  # type: KytheXrefKind
+        self.signature = d.get('signature', str())  # type: str
 
 
 class XrefSearchResult(Message):
-  DESCRIPTOR = {
-      'file': FileSpec,
-      'match': [XrefSingleMatch],
-  }
+    DESCRIPTOR = {
+        'file': FileSpec,
+        'match': [XrefSingleMatch],
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.file = d.get('file', FileSpec())  # type: FileSpec
-    self.match = d.get('match', [])  # type: List[XrefSingleMatch]
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.file = d.get('file', FileSpec())  # type: FileSpec
+        self.match = d.get('match', [])  # type: List[XrefSingleMatch]
 
 
 class XrefSearchResponse(Message):
-  DESCRIPTOR = {
-      'eliminated_type_count': [XrefTypeCount],
-      'estimated_total_type_count': [XrefTypeCount],
-      'from_kythe': bool,
-      'kythe_next_page_token': str,
-      'grok_total_number_of_results': int,  # DEPRECATED
-      'search_result': [XrefSearchResult],
-      'status': int,
-      'status_message': str,
-  }
+    DESCRIPTOR = {
+        'eliminated_type_count': [XrefTypeCount],
+        'estimated_total_type_count': [XrefTypeCount],
+        'from_kythe': bool,
+        'kythe_next_page_token': str,
+        'grok_total_number_of_results': int,  # DEPRECATED
+        'search_result': [XrefSearchResult],
+        'status': int,
+        'status_message': str,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.eliminated_type_count = d.get('eliminated_type_count',
-                                       [])  # type: List[XrefTypeCount]
-    self.estimated_total_type_count = d.get('estimated_total_type_count',
-                                            [])  # type: List[XrefTypeCount]
-    self.from_kythe = d.get('from_kythe', bool())  # type: bool
-    self.kythe_next_page_token = d.get('kythe_next_page_token',
-                                       str())  # type: str
-    self.search_result = d.get('search_result',
-                               [])  # type: List[XrefSearchResult]
-    self.status = d.get('status', int())  # type: int
-    self.status_message = d.get('status_message', str())  # type: str
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.eliminated_type_count = d.get('eliminated_type_count',
+                                           [])  # type: List[XrefTypeCount]
+        self.estimated_total_type_count = d.get('estimated_total_type_count',
+                                                [])  # type: List[XrefTypeCount]
+        self.from_kythe = d.get('from_kythe', bool())  # type: bool
+        self.kythe_next_page_token = d.get('kythe_next_page_token',
+                                           str())  # type: str
+        self.search_result = d.get('search_result',
+                                   [])  # type: List[XrefSearchResult]
+        self.status = d.get('status', int())  # type: int
+        self.status_message = d.get('status_message', str())  # type: str
 
 
 class XrefSearchRequest(Message):
-  DESCRIPTOR = {
-      'edge_filter': [EdgeEnumKind],  # DEPRECATED
-      'file_spec': FileSpec,
-      'max_num_results': int,
-      'query': str,
-  }
+    DESCRIPTOR = {
+        'edge_filter': [EdgeEnumKind],  # DEPRECATED
+        'file_spec': FileSpec,
+        'max_num_results': int,
+        'query': str,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.file_spec = d.get('file_spec', FileSpec())  # type: FileSpec
-    self.max_num_results = d.get('max_num_results', 100)  # type: int
-    self.query = d.get('query', str())  # type: str
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.file_spec = d.get('file_spec', FileSpec())  # type: FileSpec
+        self.max_num_results = d.get('max_num_results', 100)  # type: int
+        self.query = d.get('query', str())  # type: str
 
 
 class VanityGitOnBorgHostname(Message):
-  DESCRIPTOR = {
-      'name': str,
-      'hostname': str,
-  }
+    DESCRIPTOR = {
+        'name': str,
+        'hostname': str,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.name = d.get('name', str())  # type: str
-    self.hostname = d.get('hostname', str())  # type: str
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.name = d.get('name', str())  # type: str
+        self.hostname = d.get('hostname', str())  # type: str
 
 
 class InternalPackage(Message):
-  DESCRIPTOR = {
-      'browse_path_prefix': str,
-      'cs_changelist_num': str,
-      'grok_languages': [str],
-      'grok_name': str,
-      'grok_path_prefix': [str],
-      'id': str,
-      'kythe_languages': [str],
-      'name': str,
-      'repo': str,
-      'vanity_git_on_borg_hostnames': [VanityGitOnBorgHostname],
-  }
+    DESCRIPTOR = {
+        'browse_path_prefix': str,
+        'cs_changelist_num': str,
+        'grok_languages': [str],
+        'grok_name': str,
+        'grok_path_prefix': [str],
+        'id': str,
+        'kythe_languages': [str],
+        'name': str,
+        'repo': str,
+        'vanity_git_on_borg_hostnames': [VanityGitOnBorgHostname],
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.browse_path_prefix = d.get('browse_path_prefix', str())  # type: str
-    self.cs_changelist_num = d.get('cs_changelist_num', str())  # type: str
-    self.grok_languages = d.get('grok_languages', [])  # type: List[str]
-    self.grok_name = d.get('grok_name', str())  # type: str
-    self.grok_path_prefix = d.get('grok_path_prefix', [])  # type: List[str]
-    self.id = d.get('id', str())  # type: str
-    self.kythe_languages = d.get('kythe_languages', [])  # type: List[str]
-    self.name = d.get('name', str())  # type: str
-    self.repo = d.get('repo', str())  # type: str
-    self.vanity_git_on_borg_hostnames = d.get(
-        'vanity_git_on_borg_hostnames',
-        [])  # type: List[VanityGitOnBorgHostname]
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.browse_path_prefix = d.get('browse_path_prefix',
+                                        str())  # type: str
+        self.cs_changelist_num = d.get('cs_changelist_num', str())  # type: str
+        self.grok_languages = d.get('grok_languages', [])  # type: List[str]
+        self.grok_name = d.get('grok_name', str())  # type: str
+        self.grok_path_prefix = d.get('grok_path_prefix', [])  # type: List[str]
+        self.id = d.get('id', str())  # type: str
+        self.kythe_languages = d.get('kythe_languages', [])  # type: List[str]
+        self.name = d.get('name', str())  # type: str
+        self.repo = d.get('repo', str())  # type: str
+        self.vanity_git_on_borg_hostnames = d.get(
+            'vanity_git_on_borg_hostnames',
+            [])  # type: List[VanityGitOnBorgHostname]
 
 
 class StatusResponse(Message):
-  DESCRIPTOR = {
-      'announcement': str,
-      'build_label': str,
-      'internal_package': [InternalPackage],
-      'success': bool,
-  }
+    DESCRIPTOR = {
+        'announcement': str,
+        'build_label': str,
+        'internal_package': [InternalPackage],
+        'success': bool,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.announcement = d.get('announcement', str())  # type: str
-    self.build_label = d.get('build_label', str())  # type: str
-    self.internal_package = d.get('internal_package',
-                                  [])  # type: List[InternalPackage]
-    self.success = d.get('success', bool())  # type: bool
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.announcement = d.get('announcement', str())  # type: str
+        self.build_label = d.get('build_label', str())  # type: str
+        self.internal_package = d.get('internal_package',
+                                      [])  # type: List[InternalPackage]
+        self.success = d.get('success', bool())  # type: bool
 
 
 class DirInfoResponseChild(Message):
-  DESCRIPTOR = {
-      'is_deleted': bool,
-      'is_directory': bool,
-      'name': str,
-      'package_id': str,
-      'path': str,
-      'revision_num': str,
-  }
+    DESCRIPTOR = {
+        'is_deleted': bool,
+        'is_directory': bool,
+        'name': str,
+        'package_id': str,
+        'path': str,
+        'revision_num': str,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.is_deleted = d.get('is_deleted', bool())  # type: bool
-    self.is_directory = d.get('is_directory', bool())  # type: bool
-    self.name = d.get('name', str())  # type: str
-    self.package_id = d.get('package_id', str())  # type: str
-    self.path = d.get('path', str())  # type: str
-    self.revision_num = d.get('revision_num', str())  # type: str
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.is_deleted = d.get('is_deleted', bool())  # type: bool
+        self.is_directory = d.get('is_directory', bool())  # type: bool
+        self.name = d.get('name', str())  # type: str
+        self.package_id = d.get('package_id', str())  # type: str
+        self.path = d.get('path', str())  # type: str
+        self.revision_num = d.get('revision_num', str())  # type: str
 
 
 class DirInfoResponseParent(Message):
-  DESCRIPTOR = {
-      'name': str,
-      'path': str,
-      'package_id': str,
-  }
+    DESCRIPTOR = {
+        'name': str,
+        'path': str,
+        'package_id': str,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.name = d.get('name', str())  # type: str
-    self.path = d.get('path', str())  # type: str
-    self.package_id = d.get('package_id', str())  # type: str
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.name = d.get('name', str())  # type: str
+        self.path = d.get('path', str())  # type: str
+        self.package_id = d.get('package_id', str())  # type: str
 
 
 class DirInfoResponse(Message):
-  DESCRIPTOR = {
-      'child': [DirInfoResponseChild],
-      'generated': bool,
-      'gob_info': GobInfo,
-      'name': str,
-      'package_id': str,
-      'parent': [DirInfoResponseParent],
-      'path': str,
-      'success': bool,
-  }
+    DESCRIPTOR = {
+        'child': [DirInfoResponseChild],
+        'generated': bool,
+        'gob_info': GobInfo,
+        'name': str,
+        'package_id': str,
+        'parent': [DirInfoResponseParent],
+        'path': str,
+        'success': bool,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.child = d.get('child', [])  # type: List[DirInfoResponseChild]
-    self.generated = d.get('generated', bool())  # type: bool
-    self.gob_info = d.get('gob_info', GobInfo())  # type: GobInfo
-    self.name = d.get('name', str())  # type: str
-    self.package_id = d.get('package_id', str())  # type: str
-    self.parent = d.get('parent', [])  # type: List[DirInfoResponseParent]
-    self.path = d.get('path', str())  # type: str
-    self.success = d.get('success', bool())  # type: bool
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.child = d.get('child', [])  # type: List[DirInfoResponseChild]
+        self.generated = d.get('generated', bool())  # type: bool
+        self.gob_info = d.get('gob_info', GobInfo())  # type: GobInfo
+        self.name = d.get('name', str())  # type: str
+        self.package_id = d.get('package_id', str())  # type: str
+        self.parent = d.get('parent', [])  # type: List[DirInfoResponseParent]
+        self.path = d.get('path', str())  # type: str
+        self.success = d.get('success', bool())  # type: bool
 
 
 class DirInfoRequest(Message):
-  DESCRIPTOR = {
-      'file_spec': FileSpec,
-  }
+    DESCRIPTOR = {
+        'file_spec': FileSpec,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.file_spec = d.get('file_spec', FileSpec())  # type: FileSpec
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.file_spec = d.get('file_spec', FileSpec())  # type: FileSpec
 
 
 class FileResult(Message):
-  DESCRIPTOR = {
-      'display_name': AnnotatedText,
-      'file': FileSpec,
-      'license': FileSpec,
-      'license_type': str,
-      'size': int,
-  }
+    DESCRIPTOR = {
+        'display_name': AnnotatedText,
+        'file': FileSpec,
+        'license': FileSpec,
+        'license_type': str,
+        'size': int,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.display_name = d.get('display_name',
-                              AnnotatedText())  # type: AnnotatedText
-    self.file = d.get('file', FileSpec())  # type: FileSpec
-    self.license = d.get('license', FileSpec())  # type: FileSpec
-    self.license_type = d.get('license_type', str())  # type: str
-    self.size = d.get('size', int())  # type: int
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.display_name = d.get('display_name',
+                                  AnnotatedText())  # type: AnnotatedText
+        self.file = d.get('file', FileSpec())  # type: FileSpec
+        self.license = d.get('license', FileSpec())  # type: FileSpec
+        self.license_type = d.get('license_type', str())  # type: str
+        self.size = d.get('size', int())  # type: int
 
 
 class SingleMatch(Message):
-  DESCRIPTOR = {
-      'line_number': int,
-      'line_text': str,
-      'match_length': int,
-      'match_offset': int,
-      'post_context_num_lines': int,
-      'post_context_text': str,
-      'pre_context_num_lines': int,
-      'pre_context_text': str,
-      'score': int,
-  }
+    DESCRIPTOR = {
+        'line_number': int,
+        'line_text': str,
+        'match_length': int,
+        'match_offset': int,
+        'post_context_num_lines': int,
+        'post_context_text': str,
+        'pre_context_num_lines': int,
+        'pre_context_text': str,
+        'score': int,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.line_number = d.get('line_number', int())  # type: int
-    self.line_text = d.get('line_text', str())  # type: str
-    self.match_length = d.get('match_length', int())  # type: int
-    self.match_offset = d.get('match_offset', int())  # type: int
-    self.post_context_num_lines = d.get('post_context_num_lines',
-                                        int())  # type: int
-    self.post_context_text = d.get('post_context_text', str())  # type: str
-    self.pre_context_num_lines = d.get('pre_context_num_lines',
-                                       int())  # type: int
-    self.pre_context_text = d.get('pre_context_text', str())  # type: str
-    self.score = d.get('score', int())  # type: int
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.line_number = d.get('line_number', int())  # type: int
+        self.line_text = d.get('line_text', str())  # type: str
+        self.match_length = d.get('match_length', int())  # type: int
+        self.match_offset = d.get('match_offset', int())  # type: int
+        self.post_context_num_lines = d.get('post_context_num_lines',
+                                            int())  # type: int
+        self.post_context_text = d.get('post_context_text', str())  # type: str
+        self.pre_context_num_lines = d.get('pre_context_num_lines',
+                                           int())  # type: int
+        self.pre_context_text = d.get('pre_context_text', str())  # type: str
+        self.score = d.get('score', int())  # type: int
 
 
 class SearchResult(Message):
-  DESCRIPTOR = {
-      'best_matching_line_number': int,
-      'children': [str],
-      'docid': str,
-      'duplicate': [FileResult],
-      'full_history_search': bool,
-      'has_unshown_matches': bool,
-      'hit_max_matches': bool,
-      'is_augmented': bool,
-      'language': str,
-      'match': [SingleMatch],
-      'match_reason': MatchReason,
-      'num_duplicates': int,
-      'num_matches': int,
-      'snippet': [Snippet],
-      'top_file': FileResult,
-  }
+    DESCRIPTOR = {
+        'best_matching_line_number': int,
+        'children': [str],
+        'docid': str,
+        'duplicate': [FileResult],
+        'full_history_search': bool,
+        'has_unshown_matches': bool,
+        'hit_max_matches': bool,
+        'is_augmented': bool,
+        'language': str,
+        'match': [SingleMatch],
+        'match_reason': MatchReason,
+        'num_duplicates': int,
+        'num_matches': int,
+        'snippet': [Snippet],
+        'top_file': FileResult,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.best_matching_line_number = d.get('best_matching_line_number',
-                                           int())  # type: int
-    self.children = d.get('children', [])  # type: List[str]
-    self.docid = d.get('docid', str())  # type: str
-    self.duplicate = d.get('duplicate', [])  # type: List[FileResult]
-    self.has_unshown_matches = d.get('has_unshown_matches',
-                                     bool())  # type: bool
-    self.hit_max_matches = d.get('hit_max_matches', bool())  # type: bool
-    self.is_augmented = d.get('is_augmented', bool())  # type: bool
-    self.language = d.get('language', str())  # type: str
-    self.match = d.get('match', [])  # type: List[SingleMatch]
-    self.match_reason = d.get('match_reason',
-                              MatchReason())  # type: MatchReason
-    self.num_duplicates = d.get('num_duplicates', int())  # type: int
-    self.num_matches = d.get('num_matches', int())  # type: int
-    self.snippet = d.get('snippet', [])  # type: List[Snippet]
-    self.top_file = d.get('top_file', FileResult())  # type: FileResult
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.best_matching_line_number = d.get('best_matching_line_number',
+                                               int())  # type: int
+        self.children = d.get('children', [])  # type: List[str]
+        self.docid = d.get('docid', str())  # type: str
+        self.duplicate = d.get('duplicate', [])  # type: List[FileResult]
+        self.has_unshown_matches = d.get('has_unshown_matches',
+                                         bool())  # type: bool
+        self.hit_max_matches = d.get('hit_max_matches', bool())  # type: bool
+        self.is_augmented = d.get('is_augmented', bool())  # type: bool
+        self.language = d.get('language', str())  # type: str
+        self.match = d.get('match', [])  # type: List[SingleMatch]
+        self.match_reason = d.get('match_reason',
+                                  MatchReason())  # type: MatchReason
+        self.num_duplicates = d.get('num_duplicates', int())  # type: int
+        self.num_matches = d.get('num_matches', int())  # type: int
+        self.snippet = d.get('snippet', [])  # type: List[Snippet]
+        self.top_file = d.get('top_file', FileResult())  # type: FileResult
 
 
 class SearchResponse(Message):
-  DESCRIPTOR = {
-      'estimated_total_number_of_results': int,
-      'hit_max_matches_per_file': bool,
-      'hit_max_results': bool,
-      'hit_max_to_score': bool,
-      'maybe_skipped_documents': bool,
-      'next_page_token': str,
-      'results_offset': int,
-      'search_result': [SearchResult],
-      'status': int,
-      'status_message': str,
-  }
+    DESCRIPTOR = {
+        'estimated_total_number_of_results': int,
+        'hit_max_matches_per_file': bool,
+        'hit_max_results': bool,
+        'hit_max_to_score': bool,
+        'maybe_skipped_documents': bool,
+        'next_page_token': str,
+        'results_offset': int,
+        'search_result': [SearchResult],
+        'status': int,
+        'status_message': str,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.estimated_total_number_of_results = d.get(
-        'estimated_total_number_of_results', int())  # type: int
-    self.hit_max_matches_per_file = d.get('hit_max_matches_per_file',
-                                          bool())  # type: bool
-    self.hit_max_results = d.get('hit_max_results', bool())  # type: bool
-    self.hit_max_to_score = d.get('hit_max_to_score', bool())  # type: bool
-    self.maybe_skipped_documents = d.get('maybe_skipped_documents',
-                                         bool())  # type: bool
-    self.results_offset = d.get('results_offset', int())  # type: int
-    self.search_result = d.get('search_result', [])  # type: List[SearchResult]
-    self.status = d.get('status', int())  # type: int
-    self.status_message = d.get('status_message', str())  # type: str
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.estimated_total_number_of_results = d.get(
+            'estimated_total_number_of_results', int())  # type: int
+        self.hit_max_matches_per_file = d.get('hit_max_matches_per_file',
+                                              bool())  # type: bool
+        self.hit_max_results = d.get('hit_max_results', bool())  # type: bool
+        self.hit_max_to_score = d.get('hit_max_to_score', bool())  # type: bool
+        self.maybe_skipped_documents = d.get('maybe_skipped_documents',
+                                             bool())  # type: bool
+        self.results_offset = d.get('results_offset', int())  # type: int
+        self.search_result = d.get('search_result',
+                                   [])  # type: List[SearchResult]
+        self.status = d.get('status', int())  # type: int
+        self.status_message = d.get('status_message', str())  # type: str
 
 
 class SearchRequest(Message):
-  DESCRIPTOR = {
-      'exhaustive': bool,
-      'file_sizes': bool,
-      'full_history_search': bool,
-      'lines_context': int,
-      'max_num_results': int,
-      'page_token': str,
-      'query': str,
-      'results_offset': int,
-      'return_all_duplicates': bool,
-      'return_all_snippets': bool,
-      'return_local_augmented_results': bool,
-      'return_decorated_snippets': bool,
-      'return_directories': bool,
-      'return_line_matches': bool,
-      'return_snippets': bool,
-      'sort_results': bool,
-  }
+    DESCRIPTOR = {
+        'exhaustive': bool,
+        'file_sizes': bool,
+        'full_history_search': bool,
+        'lines_context': int,
+        'max_num_results': int,
+        'page_token': str,
+        'query': str,
+        'results_offset': int,
+        'return_all_duplicates': bool,
+        'return_all_snippets': bool,
+        'return_local_augmented_results': bool,
+        'return_decorated_snippets': bool,
+        'return_directories': bool,
+        'return_line_matches': bool,
+        'return_snippets': bool,
+        'sort_results': bool,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.exhaustive = d.get('exhaustive', bool())  # type: bool
-    self.lines_context = d.get('lines_context', int())  # type: int
-    self.max_num_results = d.get('max_num_results', 100)  # type: int
-    self.query = d.get('query', str())  # type: str
-    self.return_all_duplicates = d.get('return_all_duplicates',
-                                       bool())  # type: bool
-    self.return_all_snippets = d.get('return_all_snippets',
-                                     bool())  # type: bool
-    self.return_decorated_snippets = d.get('return_decorated_snippets',
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.exhaustive = d.get('exhaustive', bool())  # type: bool
+        self.lines_context = d.get('lines_context', int())  # type: int
+        self.max_num_results = d.get('max_num_results', 100)  # type: int
+        self.query = d.get('query', str())  # type: str
+        self.return_all_duplicates = d.get('return_all_duplicates',
                                            bool())  # type: bool
-    self.return_directories = d.get('return_directories', bool())  # type: bool
-    self.return_line_matches = d.get('return_line_matches',
-                                     bool())  # type: bool
-    self.return_snippets = d.get('return_snippets', bool())  # type: bool
+        self.return_all_snippets = d.get('return_all_snippets',
+                                         bool())  # type: bool
+        self.return_decorated_snippets = d.get('return_decorated_snippets',
+                                               bool())  # type: bool
+        self.return_directories = d.get('return_directories',
+                                        bool())  # type: bool
+        self.return_line_matches = d.get('return_line_matches',
+                                         bool())  # type: bool
+        self.return_snippets = d.get('return_snippets', bool())  # type: bool
 
 
 class StatusRequest(Message):
-  DESCRIPTOR = {}  # type: Dict[str,Any]
+    DESCRIPTOR = {}  # type: Dict[str,Any]
 
 
 class CompoundResponse(Message):
-  DESCRIPTOR = {
-      'annotation_response': [AnnotationResponse],
-      'call_graph_response': [CallGraphResponse],
-      'dir_info_response': [DirInfoResponse],
-      'file_info_response': [FileInfoResponse],
-      'search_response': [SearchResponse],
-      'status_response': [StatusResponse],
-      'xref_search_response': [XrefSearchResponse],
-      'elapsed_ms': int,  # Time taken to process request.
-  }
+    DESCRIPTOR = {
+        'annotation_response': [AnnotationResponse],
+        'call_graph_response': [CallGraphResponse],
+        'dir_info_response': [DirInfoResponse],
+        'file_info_response': [FileInfoResponse],
+        'search_response': [SearchResponse],
+        'status_response': [StatusResponse],
+        'xref_search_response': [XrefSearchResponse],
+        'elapsed_ms': int,  # Time taken to process request.
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.annotation_response = d.get(
-        'annotation_response', None)  # type: Optional[List[AnnotationResponse]]
-    self.call_graph_response = d.get(
-        'call_graph_response', None)  # type: Optional[List[CallGraphResponse]]
-    self.dir_info_response = d.get(
-        'dir_info_response', None)  # type: Optional[List[DirInfoResponse]]
-    self.file_info_response = d.get(
-        'file_info_response', None)  # type: Optional[List[FileInfoResponse]]
-    self.search_response = d.get('search_response',
-                                 None)  # type: Optional[List[SearchResponse]]
-    self.status_response = d.get('status_response',
-                                 None)  # type: Optional[List[StatusResponse]]
-    self.xref_search_response = d.get(
-        'xref_search_response',
-        None)  # type: Optional[List[XrefSearchResponse]]
-    self.elapsed_ms = d.get('elapsed_ms', 0)
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.annotation_response = d.get(
+            'annotation_response',
+            None)  # type: Optional[List[AnnotationResponse]]
+        self.call_graph_response = d.get(
+            'call_graph_response',
+            None)  # type: Optional[List[CallGraphResponse]]
+        self.dir_info_response = d.get(
+            'dir_info_response', None)  # type: Optional[List[DirInfoResponse]]
+        self.file_info_response = d.get(
+            'file_info_response',
+            None)  # type: Optional[List[FileInfoResponse]]
+        self.search_response = d.get(
+            'search_response', None)  # type: Optional[List[SearchResponse]]
+        self.status_response = d.get(
+            'status_response', None)  # type: Optional[List[StatusResponse]]
+        self.xref_search_response = d.get(
+            'xref_search_response',
+            None)  # type: Optional[List[XrefSearchResponse]]
+        self.elapsed_ms = d.get('elapsed_ms', 0)
 
 
 class CompoundRequest(Message):
-  DESCRIPTOR = {
-      'annotation_request': [AnnotationRequest],
-      'call_graph_request': [CallGraphRequest],
-      'dir_info_request': [DirInfoRequest],
-      'file_info_request': [FileInfoRequest],
-      'search_request': [SearchRequest],
-      'status_request': [StatusRequest],
-      'xref_search_request': [XrefSearchRequest],
-  }
+    DESCRIPTOR = {
+        'annotation_request': [AnnotationRequest],
+        'call_graph_request': [CallGraphRequest],
+        'dir_info_request': [DirInfoRequest],
+        'file_info_request': [FileInfoRequest],
+        'search_request': [SearchRequest],
+        'status_request': [StatusRequest],
+        'xref_search_request': [XrefSearchRequest],
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.annotation_request = d.get(
-        'annotation_request', None)  # type: Optional[List[AnnotationRequest]]
-    self.call_graph_request = d.get(
-        'call_graph_request', None)  # type: Optional[List[CallGraphRequest]]
-    self.dir_info_request = d.get('dir_info_request',
-                                  None)  # type: Optional[List[DirInfoRequest]]
-    self.file_info_request = d.get(
-        'file_info_request', None)  # type: Optional[List[FileInfoRequest]]
-    self.search_request = d.get('search_request',
-                                None)  # type: Optional[List[SearchRequest]]
-    self.status_request = d.get('status_request',
-                                None)  # type: Optional[List[StatusRequest]]
-    self.xref_search_request = d.get(
-        'xref_search_request', None)  # type: Optional[List[XrefSearchRequest]]
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.annotation_request = d.get(
+            'annotation_request',
+            None)  # type: Optional[List[AnnotationRequest]]
+        self.call_graph_request = d.get(
+            'call_graph_request',
+            None)  # type: Optional[List[CallGraphRequest]]
+        self.dir_info_request = d.get(
+            'dir_info_request', None)  # type: Optional[List[DirInfoRequest]]
+        self.file_info_request = d.get(
+            'file_info_request', None)  # type: Optional[List[FileInfoRequest]]
+        self.search_request = d.get('search_request',
+                                    None)  # type: Optional[List[SearchRequest]]
+        self.status_request = d.get('status_request',
+                                    None)  # type: Optional[List[StatusRequest]]
+        self.xref_search_request = d.get(
+            'xref_search_request',
+            None)  # type: Optional[List[XrefSearchRequest]]

--- a/codesearch/paths.py
+++ b/codesearch/paths.py
@@ -8,39 +8,39 @@ import os
 
 
 class NoSourceRootError(Exception):
-  """Exception raise when the CodeSearch library can't determine the location
+    """Exception raise when the CodeSearch library can't determine the location
 of the local Chromium checkout."""
-  pass
+    pass
 
 
 def GetPackageRelativePath(filename):
-  """GetPackageRelativePath returns the path to |filename| relative to the root
+    """GetPackageRelativePath returns the path to |filename| relative to the root
   of the package as determined by GetSourceRoot()."""
 
-  return os.path.relpath(filename, GetSourceRoot(filename)).replace('\\', '/')
+    return os.path.relpath(filename, GetSourceRoot(filename)).replace('\\', '/')
 
 
 def GetSourceRoot(filename):
-  """Try to determine the root of the package which contains |filename|.
+    """Try to determine the root of the package which contains |filename|.
 
   The current heuristic attempts to determine the root of the Chromium source
   tree by searching up the directory hierarchy until we find a directory
   containing src/.gn.
   """
 
-  # If filename is not absolute, then we are going to assume that it is
-  # relative to the current directory.
-  if not os.path.isabs(filename):
-    filename = os.path.abspath(filename)
-  if not os.path.exists(filename):
-    raise NoSourceRootError('File not found: {}'.format(filename))
-  source_root = os.path.dirname(filename)
-  while True:
-    gnfile = os.path.join(source_root, 'src', '.gn')
-    if os.path.exists(gnfile):
-      return source_root
+    # If filename is not absolute, then we are going to assume that it is
+    # relative to the current directory.
+    if not os.path.isabs(filename):
+        filename = os.path.abspath(filename)
+    if not os.path.exists(filename):
+        raise NoSourceRootError('File not found: {}'.format(filename))
+    source_root = os.path.dirname(filename)
+    while True:
+        gnfile = os.path.join(source_root, 'src', '.gn')
+        if os.path.exists(gnfile):
+            return source_root
 
-    new_package_root = os.path.dirname(source_root)
-    if new_package_root == source_root:
-      raise NoSourceRootError("Can't determine package root")
-    source_root = new_package_root
+        new_package_root = os.path.dirname(source_root)
+        if new_package_root == source_root:
+            raise NoSourceRootError("Can't determine package root")
+        source_root = new_package_root

--- a/codesearch/test_client_api.py
+++ b/codesearch/test_client_api.py
@@ -8,205 +8,210 @@ from __future__ import absolute_import
 
 import os
 import shutil
-import socket
-import sys
-import tempfile
 import tempfile
 import unittest
 
 from .client_api import CodeSearch, XrefNode
-from .messages import CompoundRequest, CompoundResponse, FileInfoRequest, \
-        FileInfoResponse, KytheNodeKind, KytheXrefKind, NodeEnumKind, \
-        CallGraphRequest, CallGraphResponse, Node
+from .messages import KytheNodeKind, CompoundResponse, NodeEnumKind, \
+    CallGraphResponse, Node
 from .testing_support import InstallTestRequestHandler, LastRequest, \
-        TestDataDir, DisableNetwork, EnableNetwork, DumpCallers
+    TestDataDir, DisableNetwork, EnableNetwork, DumpCallers
 
 SOURCE_ROOT = '/src/chrome/'
 
 
 class TestCodeSearch(unittest.TestCase):
+    def setUp(self):
+        InstallTestRequestHandler()
 
-  def setUp(self):
-    InstallTestRequestHandler()
+    def tearDown(self):
+        DumpCallers()
 
-  def tearDown(self):
-    DumpCallers()
+    def Touch(self, path):
+        with open(path, 'w'):
+            pass
 
-  def Touch(self, path):
-    with open(path, 'w'):
-      pass
+    def test_user_agent(self):
+        TARGET_FILE = '/src/chrome/src/net/http/http_version.h'
 
-  def test_user_agent(self):
-    TARGET_FILE = '/src/chrome/src/net/http/http_version.h'
+        codesearch = CodeSearch(source_root=SOURCE_ROOT)
+        response = codesearch.GetAnnotationsForFile(TARGET_FILE)
 
-    codesearch = CodeSearch(source_root=SOURCE_ROOT)
-    response = codesearch.GetAnnotationsForFile(TARGET_FILE)
+        self.assertTrue(isinstance(response, CompoundResponse))
+        self.assertTrue(hasattr(response, 'annotation_response'))
 
-    self.assertTrue(isinstance(response, CompoundResponse))
-    self.assertTrue(hasattr(response, 'annotation_response'))
+        request = LastRequest()
+        self.assertIsNotNone(request)
+        self.assertTrue(
+            request.get_header('User-agent').startswith(
+                'Python-CodeSearch-Client'))
 
-    request = LastRequest()
-    self.assertIsNotNone(request)
-    self.assertTrue(
-        request.get_header('User-agent').startswith('Python-CodeSearch-Client'))
+        codesearch = CodeSearch(source_root=SOURCE_ROOT,
+                                user_agent_string='Foo')
+        codesearch.GetAnnotationsForFile(TARGET_FILE)
 
-    codesearch = CodeSearch(source_root=SOURCE_ROOT, user_agent_string='Foo')
-    codesearch.GetAnnotationsForFile(TARGET_FILE)
+        request = LastRequest()
+        self.assertEqual('Foo', request.get_header('User-agent'))
 
-    request = LastRequest()
-    self.assertEqual('Foo', request.get_header('User-agent'))
+    def test_get_signatures_for_symbol(self):
+        TARGET_FILE = '/src/chrome/src/base/metrics/field_trial.h'
+        cs = CodeSearch(source_root=SOURCE_ROOT)
 
-  def test_get_signatures_for_symbol(self):
-    TARGET_FILE = '/src/chrome/src/base/metrics/field_trial.h'
-    cs = CodeSearch(source_root=SOURCE_ROOT)
+        signatures = cs.GetSignaturesForSymbol(TARGET_FILE, 'FieldTrial')
+        self.assertEqual(7, len(signatures))
 
-    signatures = cs.GetSignaturesForSymbol(TARGET_FILE, 'FieldTrial')
-    self.assertEqual(7, len(signatures))
+        signatures = cs.GetSignaturesForSymbol(TARGET_FILE, 'FieldTrial',
+                                               KytheNodeKind.RECORD_CLASS)
+        self.assertEqual(2, len(signatures))
 
-    signatures = cs.GetSignaturesForSymbol(TARGET_FILE, 'FieldTrial',
-                                           KytheNodeKind.RECORD_CLASS)
-    self.assertEqual(2, len(signatures))
+        signatures = cs.GetSignaturesForSymbol(
+            TARGET_FILE, 'FieldTrial', KytheNodeKind.FUNCTION_CONSTRUCTOR)
+        self.assertEqual(3, len(signatures))
 
-    signatures = cs.GetSignaturesForSymbol(TARGET_FILE, 'FieldTrial',
-                                           KytheNodeKind.FUNCTION_CONSTRUCTOR)
-    self.assertEqual(3, len(signatures))
+    def test_gob_revision(self):
+        TARGET_FILE = '/src/chrome/src/README.md'
+        cs = CodeSearch(source_root=SOURCE_ROOT)
 
-  def test_gob_revision(self):
-    TARGET_FILE = '/src/chrome/src/README.md'
-    cs = CodeSearch(source_root=SOURCE_ROOT)
+        self.assertEqual('', cs.GetRevision())
+        cs.GetFileInfo(TARGET_FILE)
+        self.assertEqual(40, len(cs.GetRevision()))
 
-    self.assertEqual('', cs.GetRevision())
-    fi = cs.GetFileInfo(TARGET_FILE)
-    self.assertEqual(40, len(cs.GetRevision()))
+    def test_get_signature_for_symbol(self):
+        # These values are likely to change pretty often. So this test will
+        # likely fail each time we refresh the test data corpus. If that
+        # happens, open up field_trial.h in https://cs.chromium.org and verify
+        # that the tickets that get picked up by the API make sense.
 
-  def test_get_signature_for_symbol(self):
-    # These values are likely to change pretty often. So this test will likely
-    # fail each time we refresh the test data corpus. If that happens, open up
-    # field_trial.h in https://cs.chromium.org and verify that the tickets that
-    # get picked up by the API make sense.
+        TARGET_FILE = '/src/chrome/src/base/metrics/field_trial.h'
+        cs = CodeSearch(source_root=SOURCE_ROOT)
 
-    TARGET_FILE = '/src/chrome/src/base/metrics/field_trial.h'
-    cs = CodeSearch(source_root=SOURCE_ROOT)
+        # A class definition. The name appears numerous times in the file.
+        self.assertEqual(
+            cs.GetSignatureForSymbol(TARGET_FILE, 'FieldTrial'),
+            'kythe://chromium?lang=c%2B%2B?path=src/base/metrics/field_trial.h'
+            '#FieldTrial%3Abase%23c%23cGxmCcu4cj8')
 
-    # A class definition. The name appears numerous times in the file.
-    self.assertEqual(
-        cs.GetSignatureForSymbol(TARGET_FILE, 'FieldTrial'),
-        'kythe://chromium?lang=c%2B%2B?path=src/base/metrics/field_trial.h#FieldTrial%3Abase%23c%23cGxmCcu4cj8'
-    )
+        # An enum defined within the class.
+        self.assertEqual(
+            cs.GetSignatureForSymbol(TARGET_FILE, 'RandomizationType'),
+            'kythe://chromium?lang=c%2B%2B?path=src/base/metrics/field_trial.h#'
+            'sffJe7wAnF2I9rS3Yd%2B8%2FcTJryczxcrLGG1xREnxhKU%3D')
 
-    # An enum defined within the class.
-    self.assertEqual(
-        cs.GetSignatureForSymbol(TARGET_FILE, 'RandomizationType'),
-        'kythe://chromium?lang=c%2B%2B?path=src/base/metrics/field_trial.h#sffJe7wAnF2I9rS3Yd%2B8%2FcTJryczxcrLGG1xREnxhKU%3D'
-    )
+        # A struct field.
+        self.assertEqual(
+            cs.GetSignatureForSymbol(TARGET_FILE, 'pickle_size'),
+            'kythe://chromium?lang=c%2B%2B?path=src/base/metrics/field_trial.h#'
+            '5j4rU1ruIZUCxPWsXAOsTjOIQPiJdmvDwkVVxoqsqT8%3D')
 
-    # A struct field.
-    self.assertEqual(
-        cs.GetSignatureForSymbol(TARGET_FILE, 'pickle_size'),
-        'kythe://chromium?lang=c%2B%2B?path=src/base/metrics/field_trial.h#5j4rU1ruIZUCxPWsXAOsTjOIQPiJdmvDwkVVxoqsqT8%3D'
-    )
+        # A parameter to a function.
+        self.assertEqual(
+            cs.GetSignatureForSymbol(TARGET_FILE, 'override_entropy_provider'),
+            'kythe://chromium?lang=c%2B%2B?path=src/base/metrics/field_trial.h#'
+            'lAGs5biYnnRyEje0KIGqTe4V5ZkjOY6%2B7I2jg8Jlxdk%3D')
 
-    # A parameter to a function.
-    self.assertEqual(
-        cs.GetSignatureForSymbol(TARGET_FILE, 'override_entropy_provider'),
-        'kythe://chromium?lang=c%2B%2B?path=src/base/metrics/field_trial.h#lAGs5biYnnRyEje0KIGqTe4V5ZkjOY6%2B7I2jg8Jlxdk%3D'
-    )
+        # A builtin type.
+        self.assertEqual(
+            cs.GetSignatureForSymbol(TARGET_FILE, 'uint32_t'),
+            'kythe:?lang=c%2B%2B'
+            '#9Q1Qo0dt%2BgETZA3AE5IlwTBVpnGb9lT0KTUS8YtMp7E%3D'
+        )
 
-    # A builtin type.
-    self.assertEqual(
-        cs.GetSignatureForSymbol(TARGET_FILE, 'uint32_t'),
-        'kythe:?lang=c%2B%2B#9Q1Qo0dt%2BgETZA3AE5IlwTBVpnGb9lT0KTUS8YtMp7E%3D')
+        # The absence of the "md5" parameter to the annotation_request was
+        # puzzlingly causing the annotations for this file to be offset by a
+        # constant amount.
+        self.assertEqual(
+            cs.GetSignatureForSymbol(
+                '/src/chrome/src/chrome/browser/'
+                'chrome_content_browser_client.cc',
+                'IsURLWhitelisted'),
+            'kythe://chromium?lang=c%2B%2B?path=src/chrome/browser/'
+            'chrome_content_browser_client.cc#'
+            'Fwd4bLZKrcXZ1sb8TmkFDxFtI76Z3V%2BWSTgS%2Bov3Ag8%3D')
 
-    # The absence of the "md5" parameter to the annotation_request was
-    # puzzlingly causing the annotations for this file to be offset by a
-    # constant amount.
-    self.assertEqual(
-        cs.GetSignatureForSymbol(
-            '/src/chrome/src/chrome/browser/chrome_content_browser_client.cc',
-            'IsURLWhitelisted'),
-        'kythe://chromium?lang=c%2B%2B?path=src/chrome/browser/chrome_content_browser_client.cc#Fwd4bLZKrcXZ1sb8TmkFDxFtI76Z3V%2BWSTgS%2Bov3Ag8%3D'
-    )
+    def test_search_for_symbol(self):
+        cs = CodeSearch(source_root='.')
 
-  def test_search_for_symbol(self):
-    cs = CodeSearch(source_root='.')
+        signatures = cs.SearchForSymbol('base::FieldTrial$', NodeEnumKind.CLASS)
+        self.assertEqual(1, len(signatures))
+        self.assertTrue(isinstance(signatures[0], XrefNode))
 
-    signatures = cs.SearchForSymbol('base::FieldTrial$', NodeEnumKind.CLASS)
-    self.assertEqual(1, len(signatures))
-    self.assertTrue(isinstance(signatures[0], XrefNode))
-
-    signatures = cs.SearchForSymbol('URLRequestJob', NodeEnumKind.CLASS)
-    self.assertEqual(1, len(signatures))
-    self.assertTrue(isinstance(signatures[0], XrefNode))
-
-    signatures = cs.SearchForSymbol('BackgroundSyncService::Register',
-                                    NodeEnumKind.METHOD)
-    self.assertEqual(1, len(signatures))
-
-    signatures = cs.SearchForSymbol(
-        'BackgroundSyncService::Register',
-        NodeEnumKind.METHOD,
-        return_all_results=True)
-    self.assertEqual(2, len(signatures))
-
-  def test_get_call_graph(self):
-    cs = CodeSearch(source_root='.')
-    signatures = cs.SearchForSymbol('HttpAuth::ChooseBestChallenge',
-                                    NodeEnumKind.FUNCTION)
-    self.assertEqual(1, len(signatures))
-    self.assertIsInstance(signatures[0], XrefNode)
-    cg_response = cs.GetCallGraph(signature=signatures[0].GetSignature())
-    self.assertIsInstance(cg_response, CompoundResponse)
-    self.assertIsInstance(cg_response.call_graph_response[0], CallGraphResponse)
-    self.assertIsInstance(cg_response.call_graph_response[0].node, Node)
-
-  def test_fixed_cache(self):
-    fixed_cache_dir = os.path.join(TestDataDir(), 'fixed_cache')
-
-    # There are no resources corresponding to the requests that are going to be
-    # made under this test. Instead there are cached resources. The cache
-    # expiration is set for 10 years, which should be long enough for anybody.
-
-    # Note that whenever the request parameters change, the fixed cache will
-    # stop working. Hence we need to regenerate the test data. To do that:
-    #
-    # - Remove all the files from testdata/fixed_cache/*
-    # - Comment out the DisableNetwork() call below.
-    # - Run the test in rebaseline mode.
-    # - *DONT* add any of the new cache entries added to testdata/resource/*
-    # - *DO* add the new files that show up in testdata/fixed_cache/*
-
-    DisableNetwork()
-    cs = CodeSearch(
-        source_root='.',
-        should_cache=True,
-        cache_dir=fixed_cache_dir,
-        cache_timeout_in_seconds=10 * 365 * 24 * 60 * 60)
-    try:
-      signatures = cs.SearchForSymbol(
-          'URLRequestHttpJob', NodeEnumKind.CLASS, max_results_to_analyze=50)
-    finally:
-      EnableNetwork()
-      cs.TeardownCache()
-    self.assertEqual(1, len(signatures))
-
-  def test_with_cache_dir(self):
-    test_dir = tempfile.mkdtemp()
-    try:
-      cs = CodeSearch(source_root='.', should_cache=True, cache_dir=test_dir)
-      try:
         signatures = cs.SearchForSymbol('URLRequestJob', NodeEnumKind.CLASS)
-      finally:
-        cs.TeardownCache()
-      self.assertEqual(1, len(signatures))
+        self.assertEqual(1, len(signatures))
+        self.assertTrue(isinstance(signatures[0], XrefNode))
 
-      entries = os.listdir(test_dir)
-      # Test the count of entries. The exact set of entries will change from
-      # time to time due to changes in queries and repsonses.
-      self.assertEqual(3, len(entries))
+        signatures = cs.SearchForSymbol('BackgroundSyncService::Register',
+                                        NodeEnumKind.METHOD)
+        self.assertEqual(1, len(signatures))
 
-    finally:
-      shutil.rmtree(test_dir)
+        signatures = cs.SearchForSymbol('BackgroundSyncService::Register',
+                                        NodeEnumKind.METHOD,
+                                        return_all_results=True)
+        self.assertEqual(2, len(signatures))
+
+    def test_get_call_graph(self):
+        cs = CodeSearch(source_root='.')
+        signatures = cs.SearchForSymbol('HttpAuth::ChooseBestChallenge',
+                                        NodeEnumKind.FUNCTION)
+        self.assertEqual(1, len(signatures))
+        self.assertIsInstance(signatures[0], XrefNode)
+        cg_response = cs.GetCallGraph(signature=signatures[0].GetSignature())
+        self.assertIsInstance(cg_response, CompoundResponse)
+        self.assertIsInstance(cg_response.call_graph_response[0],
+                              CallGraphResponse)
+        self.assertIsInstance(cg_response.call_graph_response[0].node, Node)
+
+    def test_fixed_cache(self):
+        fixed_cache_dir = os.path.join(TestDataDir(), 'fixed_cache')
+
+        # There are no resources corresponding to the requests that are going to
+        # be made under this test. Instead there are cached resources. The cache
+        # expiration is set for 10 years, which should be long enough for
+        # anybody.
+
+        # Note that whenever the request parameters change, the fixed cache will
+        # stop working. Hence we need to regenerate the test data. To do that:
+        #
+        # - Remove all the files from testdata/fixed_cache/*
+        # - Comment out the DisableNetwork() call below.
+        # - Run the test in rebaseline mode.
+        # - *DONT* add any of the new cache entries added to testdata/resource/*
+        # - *DO* add the new files that show up in testdata/fixed_cache/*
+
+        DisableNetwork()
+        cs = CodeSearch(source_root='.',
+                        should_cache=True,
+                        cache_dir=fixed_cache_dir,
+                        cache_timeout_in_seconds=10 * 365 * 24 * 60 * 60)
+        try:
+            signatures = cs.SearchForSymbol('URLRequestHttpJob',
+                                            NodeEnumKind.CLASS,
+                                            max_results_to_analyze=50)
+        finally:
+            EnableNetwork()
+            cs.TeardownCache()
+        self.assertEqual(1, len(signatures))
+
+    def test_with_cache_dir(self):
+        test_dir = tempfile.mkdtemp()
+        try:
+            cs = CodeSearch(source_root='.',
+                            should_cache=True,
+                            cache_dir=test_dir)
+            try:
+                signatures = cs.SearchForSymbol('URLRequestJob',
+                                                NodeEnumKind.CLASS)
+            finally:
+                cs.TeardownCache()
+            self.assertEqual(1, len(signatures))
+
+            entries = os.listdir(test_dir)
+            # Test the count of entries. The exact set of entries will change
+            # from time to time due to changes in queries and repsonses.
+            self.assertEqual(3, len(entries))
+
+        finally:
+            shutil.rmtree(test_dir)
 
 
 if __name__ == '__main__':
-  unittest.main()
+    unittest.main()

--- a/codesearch/test_codeblocks.py
+++ b/codesearch/test_codeblocks.py
@@ -6,41 +6,40 @@
 
 import unittest
 
-from .client_api import CsFile, CodeSearch
-from .messages import FileInfo, TextRange, NodeEnumKind, CodeBlock, CodeBlockType
+from .client_api import CodeSearch
+from .messages import CodeBlock, CodeBlockType
 from .testing_support import InstallTestRequestHandler
 
 
 class TestCodeBlocks(unittest.TestCase):
+    def setUp(self):
+        InstallTestRequestHandler()
 
-  def setUp(self):
-    InstallTestRequestHandler()
+    def test_get_codeblock(self):
+        cs = CodeSearch(source_root='/src/chrome/')
+        cs_file = cs.GetFileInfo('/src/chrome/src/net/http/http_auth.h')
+        block = cs_file.GetCodeBlock()
+        self.assertIsInstance(block, CodeBlock)
+        self.assertNotEqual(0, len(block.child))
+        self.assertIsInstance(block.child[0], CodeBlock)
 
-  def test_get_codeblock(self):
-    cs = CodeSearch(source_root='/src/chrome/')
-    cs_file = cs.GetFileInfo('/src/chrome/src/net/http/http_auth.h')
-    block = cs_file.GetCodeBlock()
-    self.assertIsInstance(block, CodeBlock)
-    self.assertNotEqual(0, len(block.child))
-    self.assertIsInstance(block.child[0], CodeBlock)
+    def test_find(self):
+        cs = CodeSearch(source_root='/src/chrome/')
+        cs_file = cs.GetFileInfo('/src/chrome/src/net/http/http_auth.h')
+        block = cs_file.FindCodeBlock()
+        self.assertIsNotNone(block)
+        self.assertIsInstance(block, CodeBlock)
+        self.assertEqual(block, cs_file.GetCodeBlock(), "should match root")
 
-  def test_find(self):
-    cs = CodeSearch(source_root='/src/chrome/')
-    cs_file = cs.GetFileInfo('/src/chrome/src/net/http/http_auth.h')
-    block = cs_file.FindCodeBlock()
-    self.assertIsNotNone(block)
-    self.assertIsInstance(block, CodeBlock)
-    self.assertEqual(block, cs_file.GetCodeBlock(), "should match root")
+        block = cs_file.FindCodeBlock("net", CodeBlockType.NAMESPACE)
+        self.assertIsNotNone(block)
+        self.assertEqual(block.name, "net")
 
-    block = cs_file.FindCodeBlock("net", CodeBlockType.NAMESPACE)
-    self.assertIsNotNone(block)
-    self.assertEqual(block.name, "net")
-
-    block = cs_file.FindCodeBlock("HandleChallengeResponse",
-                                  CodeBlockType.FUNCTION)
-    self.assertIsNotNone(block)
-    self.assertEqual(block.name, "HandleChallengeResponse")
+        block = cs_file.FindCodeBlock("HandleChallengeResponse",
+                                      CodeBlockType.FUNCTION)
+        self.assertIsNotNone(block)
+        self.assertEqual(block.name, "HandleChallengeResponse")
 
 
 if __name__ == '__main__':
-  unittest.main()
+    unittest.main()

--- a/codesearch/test_cs_file.py
+++ b/codesearch/test_cs_file.py
@@ -6,84 +6,90 @@
 
 import unittest
 
-from .client_api import CsFile, CodeSearch
-from .messages import FileInfo, TextRange, NodeEnumKind, CodeBlock, CodeBlockType, AnnotationTypeValue
+from .client_api import CodeSearch
+from .messages import TextRange, CodeBlock, CodeBlockType, AnnotationTypeValue
 from .testing_support import InstallTestRequestHandler
 
 
 class TestCsFile(unittest.TestCase):
+    def setUp(self):
+        InstallTestRequestHandler()
 
-  def setUp(self):
-    InstallTestRequestHandler()
+    def test_text_range(self):
+        cs = CodeSearch(source_root='/src/chrome/')
+        cs_file = cs.GetFileInfo('/src/chrome/src/LICENSE')
 
-  def test_text_range(self):
-    cs = CodeSearch(source_root='/src/chrome/')
-    cs_file = cs.GetFileInfo('/src/chrome/src/LICENSE')
+        self.assertEqual(
+            "// Redistribution and use",
+            cs_file.Text(
+                TextRange(start_line=3,
+                          start_column=1,
+                          end_line=3,
+                          end_column=25)))
 
-    self.assertEqual(
-        "// Redistribution and use",
-        cs_file.Text(
-            TextRange(start_line=3, start_column=1, end_line=3, end_column=25)))
+        self.assertEqual(
+            "CONTRIBUTORS\n/",
+            cs_file.Text(
+                TextRange(start_line=17,
+                          start_column=59,
+                          end_line=18,
+                          end_column=1)))
 
-    self.assertEqual(
-        "CONTRIBUTORS\n/",
-        cs_file.Text(
-            TextRange(
-                start_line=17, start_column=59, end_line=18, end_column=1)))
-
-    self.assertEqual(
-        """CONTRIBUTORS
+        self.assertEqual(
+            """CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 //""",
-        cs_file.Text(
-            TextRange(
-                start_line=17, start_column=59, end_line=19, end_column=2)))
+            cs_file.Text(
+                TextRange(start_line=17,
+                          start_column=59,
+                          end_line=19,
+                          end_column=2)))
 
-  def test_path(self):
-    cs = CodeSearch(source_root='/src/chrome/')
-    cs_file = cs.GetFileInfo('/src/chrome/src/LICENSE')
-    self.assertEqual(cs_file.Path(), 'src/LICENSE')
+    def test_path(self):
+        cs = CodeSearch(source_root='/src/chrome/')
+        cs_file = cs.GetFileInfo('/src/chrome/src/LICENSE')
+        self.assertEqual(cs_file.Path(), 'src/LICENSE')
 
-  def test_display_name(self):
-    cs = CodeSearch(source_root='/src/chrome/')
-    cs_file = cs.GetFileInfo('/src/chrome/src/net/http/http_auth.h')
-    self.assertEqual(
-        cs_file.GetAnchorText(
-            'kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h#HttpAuth%3Anet%23c%23hUTvau_Z32C'
-        ), 'HttpAuth')
+    def test_display_name(self):
+        cs = CodeSearch(source_root='/src/chrome/')
+        cs_file = cs.GetFileInfo('/src/chrome/src/net/http/http_auth.h')
+        self.assertEqual(
+            cs_file.GetAnchorText(
+                'kythe://chromium?lang=c%2B%2B?path=src/net/http/http_auth.h'
+                '#HttpAuth%3Anet%23c%23hUTvau_Z32C'), 'HttpAuth')
 
-  def test_get_codeblock(self):
-    cs = CodeSearch(source_root='/src/chrome/')
-    cs_file = cs.GetFileInfo('/src/chrome/src/net/http/http_auth.h')
-    block = cs_file.GetCodeBlock()
-    self.assertIsInstance(block, CodeBlock)
-    self.assertNotEqual(0, len(block.child))
-    self.assertIsInstance(block.child[0], CodeBlock)
+    def test_get_codeblock(self):
+        cs = CodeSearch(source_root='/src/chrome/')
+        cs_file = cs.GetFileInfo('/src/chrome/src/net/http/http_auth.h')
+        block = cs_file.GetCodeBlock()
+        self.assertIsInstance(block, CodeBlock)
+        self.assertNotEqual(0, len(block.child))
+        self.assertIsInstance(block.child[0], CodeBlock)
 
-  def test_get_signature_for_codeblock(self):
-    cs = CodeSearch(source_root='/src/chrome/')
-    cs_file = cs.GetFileInfo('/src/chrome/src/net/http/http_auth.h')
-    block = cs_file.FindCodeBlock(
-        name="AuthorizationResult", type=CodeBlockType.ENUM)
-    self.assertIsNotNone(block)
-    sig = cs_file.GetSignatureForCodeBlock(block)
-    self.assertIsNotNone(sig)
-    self.assertNotEqual("", sig)
+    def test_get_signature_for_codeblock(self):
+        cs = CodeSearch(source_root='/src/chrome/')
+        cs_file = cs.GetFileInfo('/src/chrome/src/net/http/http_auth.h')
+        block = cs_file.FindCodeBlock(name="AuthorizationResult",
+                                      type=CodeBlockType.ENUM)
+        self.assertIsNotNone(block)
+        sig = cs_file.GetSignatureForCodeBlock(block)
+        self.assertIsNotNone(sig)
+        self.assertNotEqual("", sig)
 
-  def test_get_annotations_types(self):
-    cs = CodeSearch(source_root='/src/chrome/')
-    cs_file = cs.GetFileInfo('/src/chrome/src/net/http/http_auth.h')
-    annotations = cs_file.GetAnnotations()
-    found_xref_signature = False
-    found_link_to_definition = False
-    for annotation in annotations:
-      if annotation.type.id == AnnotationTypeValue.XREF_SIGNATURE:
-        found_xref_signature = True
-      if annotation.type.id == AnnotationTypeValue.LINK_TO_DEFINITION:
-        found_link_to_definition = True
-    self.assertTrue(found_xref_signature)
-    self.assertTrue(found_link_to_definition)
+    def test_get_annotations_types(self):
+        cs = CodeSearch(source_root='/src/chrome/')
+        cs_file = cs.GetFileInfo('/src/chrome/src/net/http/http_auth.h')
+        annotations = cs_file.GetAnnotations()
+        found_xref_signature = False
+        found_link_to_definition = False
+        for annotation in annotations:
+            if annotation.type.id == AnnotationTypeValue.XREF_SIGNATURE:
+                found_xref_signature = True
+            if annotation.type.id == AnnotationTypeValue.LINK_TO_DEFINITION:
+                found_link_to_definition = True
+        self.assertTrue(found_xref_signature)
+        self.assertTrue(found_link_to_definition)
 
 
 if __name__ == '__main__':
-  unittest.main()
+    unittest.main()

--- a/codesearch/test_file_cache.py
+++ b/codesearch/test_file_cache.py
@@ -14,40 +14,39 @@ from .file_cache import FileCache
 
 
 class TestFileCache(unittest.TestCase):
+    def test_with_no_cache_dir(self):
+        try:
+            f = FileCache()
+            f.put('foo', 'hello'.encode('utf-8'))
+            self.assertEqual('hello'.encode('utf-8'), f.get('foo'))
+        finally:
+            f.close()
 
-  def test_with_no_cache_dir(self):
-    try:
-      f = FileCache()
-      f.put('foo', 'hello'.encode('utf-8'))
-      self.assertEqual('hello'.encode('utf-8'), f.get('foo'))
-    finally:
-      f.close()
+    def test_with_cache_dir(self):
+        f = None
+        g = None
+        test_dir = None
+        try:
+            test_dir = tempfile.mkdtemp()
+            test_cache_dir = os.path.join(test_dir, 'cache')
+            f = FileCache(cache_dir=test_cache_dir)
+            f.put('foo', 'hello'.encode('utf-8'))
+            f.close()
+            f = None
 
-  def test_with_cache_dir(self):
-    f = None
-    g = None
-    test_dir = None
-    try:
-      test_dir = tempfile.mkdtemp()
-      test_cache_dir = os.path.join(test_dir, 'cache')
-      f = FileCache(cache_dir=test_cache_dir)
-      f.put('foo', 'hello'.encode('utf-8'))
-      f.close()
-      f = None
+            g = FileCache(cache_dir=test_cache_dir)
+            self.assertEqual('hello'.encode('utf-8'), g.get('foo'))
+            g.close()
+            g = None
 
-      g = FileCache(cache_dir=test_cache_dir)
-      self.assertEqual('hello'.encode('utf-8'), g.get('foo'))
-      g.close()
-      g = None
-
-    finally:
-      if f:
-        f.close()
-      if g:
-        g.close()
-      if test_dir:
-        shutil.rmtree(test_dir)
+        finally:
+            if f:
+                f.close()
+            if g:
+                g.close()
+            if test_dir:
+                shutil.rmtree(test_dir)
 
 
 if __name__ == '__main__':
-  unittest.main()
+    unittest.main()

--- a/codesearch/test_messages.py
+++ b/codesearch/test_messages.py
@@ -18,285 +18,280 @@ from .messages import  \
     XrefSignature
 
 try:
-  from typing import List
+    from typing import List
 except ImportError:
-  pass
+    pass
 
 
 class Foo(Message):
-  DESCRIPTOR = {
-      'x': int,
-  }
+    DESCRIPTOR = {
+        'x': int,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.x = d.get('x', int())  # type: int
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.x = d.get('x', int())  # type: int
 
 
 class Bar(Message):
-  DESCRIPTOR = {
-      'x': int,
-      'y': [Message.PARENT_TYPE],
-  }
+    DESCRIPTOR = {
+        'x': int,
+        'y': [Message.PARENT_TYPE],
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.x = d.get('x', int())  # type: int
-    self.y = d.get('y', [])  # type: List[Bar]
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.x = d.get('x', int())  # type: int
+        self.y = d.get('y', [])  # type: List[Bar]
 
 
 class Baz(Message):
-  DESCRIPTOR = {
-      'x': int,
-      'y': [Message.PARENT_TYPE],
-  }
+    DESCRIPTOR = {
+        'x': int,
+        'y': [Message.PARENT_TYPE],
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.x = d.get('x', int())  # type: int
-    self.y = d.get('y', [])  # type: List[Baz]
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.x = d.get('x', int())  # type: int
+        self.y = d.get('y', [])  # type: List[Baz]
 
 
 class Qux(Message):
-  FOO = 1
-  BAR = 2
+    FOO = 1
+    BAR = 2
 
-  DESCRIPTOR = int
+    DESCRIPTOR = int
 
 
 class Quux(Message):
-  DESCRIPTOR = {
-      'x': Qux,
-  }
+    DESCRIPTOR = {
+        'x': Qux,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.x = d.get('x', 0)  # type: int
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.x = d.get('x', 0)  # type: int
 
 
 class S(Message):
-  DESCRIPTOR = {
-      's': str,
-  }
+    DESCRIPTOR = {
+        's': str,
+    }
 
-  def __init__(self, **kwargs):
-    d = kwargs
-    self.s = d.get('s', str())  # type: str
+    def __init__(self, **kwargs):
+        d = kwargs
+        self.s = d.get('s', str())  # type: str
 
 
 class TestProto(unittest.TestCase):
+    def test_proto_bridge(self):
+        v = Foo()
+        v.x = 3
+        self.assertEqual(v.AsQueryString(), [('x', '3')])
 
-  def test_proto_bridge(self):
-    v = Foo()
-    v.x = 3
-    self.assertEqual(v.AsQueryString(), [('x', '3')])
+    def test_from_json_string_1(self):
+        v = Message.FromJsonString('{"x": 3}')
+        self.assertEqual(v.x, 3)
 
-  def test_from_json_string_1(self):
-    v = Message.FromJsonString('{"x": 3}')
-    self.assertEqual(v.x, 3)
+    def test_from_json_string_2(self):
+        v = Foo.FromJsonString('{"x": 3}')
+        self.assertTrue(isinstance(v, Foo))
+        self.assertTrue(isinstance(v.x, int))
+        self.assertEqual(v.x, 3)
 
-  def test_from_json_string_2(self):
-    v = Foo.FromJsonString('{"x": 3}')
-    self.assertTrue(isinstance(v, Foo))
-    self.assertTrue(isinstance(v.x, int))
-    self.assertEqual(v.x, 3)
+    def test_from_json_string_3(self):
+        v = Bar.FromJsonString('{"x": 3, "y": [{"x": 4}]}')
+        self.assertTrue(isinstance(v, Bar))
+        self.assertTrue(isinstance(v.y[0], Bar))
+        self.assertEqual(v.x, 3)
+        self.assertEqual(v.y[0].x, 4)
 
-  def test_from_json_string_3(self):
-    v = Bar.FromJsonString('{"x": 3, "y": [{"x": 4}]}')
-    self.assertTrue(isinstance(v, Bar))
-    self.assertTrue(isinstance(v.y[0], Bar))
-    self.assertEqual(v.x, 3)
-    self.assertEqual(v.y[0].x, 4)
+    def test_from_json_string_4(self):
+        v = Foo.FromJsonString('{"y": 3}')
+        self.assertTrue(isinstance(v, Foo))
 
-  def test_from_json_string_4(self):
-    v = Foo.FromJsonString('{"y": 3}')
-    self.assertTrue(isinstance(v, Foo))
+    def test_from_json_string_5(self):
+        v = Foo.FromJsonString('{"y": 3}')
+        self.assertTrue(isinstance(v, Foo))
+        self.assertFalse(hasattr(v, 'y'))
 
-  def test_from_json_string_5(self):
-    v = Foo.FromJsonString('{"y": 3}')
-    self.assertTrue(isinstance(v, Foo))
-    self.assertFalse(hasattr(v, 'y'))
+    def test_from_json_string_6(self):
+        v = Quux.FromJsonString('{"x": 3}')
+        self.assertTrue(isinstance(v, Quux))
+        self.assertTrue(isinstance(v.x, int))
+        self.assertEqual(v.x, 3)
 
-  def test_from_json_string_6(self):
-    v = Quux.FromJsonString('{"x": 3}')
-    self.assertTrue(isinstance(v, Quux))
-    self.assertTrue(isinstance(v.x, int))
-    self.assertEqual(v.x, 3)
+    def test_from_json_string_7(self):
+        v = Quux.FromJsonString('{"x": "FOO"}')
+        self.assertTrue(isinstance(v, Quux))
+        self.assertTrue(isinstance(v.x, int))
+        self.assertEqual(v.x, 1)
 
-  def test_from_json_string_7(self):
-    v = Quux.FromJsonString('{"x": "FOO"}')
-    self.assertTrue(isinstance(v, Quux))
-    self.assertTrue(isinstance(v.x, int))
-    self.assertEqual(v.x, 1)
+    def test_from_json_string_invalid(self):
+        s = bytearray('{"s": "abcdefghijklmnop"}'.encode('utf-8'))
+        s[8] = 0xf8
+        v = S.FromJsonString(s)
+        self.assertTrue(isinstance(v, S))
+        self.assertGreater(len(v.s), 0)
 
-  def test_from_json_string_invalid(self):
-    s = bytearray('{"s": "abcdefghijklmnop"}'.encode('utf-8'))
-    s[8] = 0xf8
-    v = S.FromJsonString(s)
-    self.assertTrue(isinstance(v, S))
-    self.assertGreater(len(v.s), 0)
-
-  def test_from_shallow_dict_1(self):
-    v = Baz.FromShallowDict({'x': 3, 'y': [{'x': 4}, {'x': 5}]})
-    self.assertTrue(isinstance(v, Baz))
-    self.assertTrue(isinstance(v.y, list))
-    self.assertTrue(isinstance(v.y[0], Baz))
-    self.assertTrue(isinstance(v.y[1], Baz))
+    def test_from_shallow_dict_1(self):
+        v = Baz.FromShallowDict({'x': 3, 'y': [{'x': 4}, {'x': 5}]})
+        self.assertTrue(isinstance(v, Baz))
+        self.assertTrue(isinstance(v.y, list))
+        self.assertTrue(isinstance(v.y[0], Baz))
+        self.assertTrue(isinstance(v.y[1], Baz))
 
 
 class TestConstructor(unittest.TestCase):
+    def test_empty_class(self):
+        f = Foo()
+        self.assertTrue(hasattr(f, 'x'))
 
-  def test_empty_class(self):
-    f = Foo()
-    self.assertTrue(hasattr(f, 'x'))
-
-  def test_class_with_known_keyword(self):
-    f = Foo(x=10)
-    self.assertTrue(hasattr(f, 'x'))
-    self.assertEqual(10, f.x)
+    def test_class_with_known_keyword(self):
+        f = Foo(x=10)
+        self.assertTrue(hasattr(f, 'x'))
+        self.assertEqual(10, f.x)
 
 
 class TestXrefSignature(unittest.TestCase):
+    def test_basic_with_single_signature(self):
+        xsig = XrefSignature.FromJsonString('{"highlight_signature":"abc", '
+                                            '"signature":"sig",'
+                                            '"signature_hash":"hash"}')
+        self.assertEqual('abc', xsig.highlight_signature)
+        self.assertEqual('sig', xsig.signature)
+        self.assertEqual('hash', xsig.signature_hash)
+        self.assertSetEqual(set(['abc', 'sig']), set(xsig.GetSignatures()))
+        self.assertEqual('sig', xsig.GetSignature())
 
-  def test_basic_with_single_signature(self):
-    xsig = XrefSignature.FromJsonString(
-        '{"highlight_signature":"abc", "signature":"sig","signature_hash":"hash"}'
-    )
-    self.assertEqual('abc', xsig.highlight_signature)
-    self.assertEqual('sig', xsig.signature)
-    self.assertEqual('hash', xsig.signature_hash)
-    self.assertSetEqual(set(['abc', 'sig']), set(xsig.GetSignatures()))
-    self.assertEqual('sig', xsig.GetSignature())
-
-  def test_multi_strings(self):
-    xsig = XrefSignature.FromJsonString('''{
+    def test_multi_strings(self):
+        xsig = XrefSignature.FromJsonString('''{
         "signature": "foo bar baz",
         "highlight_signature": "hifoo hibar"
       }''')
-    self.assertSetEqual(
-        set(['foo', 'bar', 'baz', 'hifoo', 'hibar']), set(xsig.GetSignatures()))
-    self.assertEqual('foo', xsig.GetSignature())
+        self.assertSetEqual(set(['foo', 'bar', 'baz', 'hifoo', 'hibar']),
+                            set(xsig.GetSignatures()))
+        self.assertEqual('foo', xsig.GetSignature())
 
 
 class TestInternalLink(unittest.TestCase):
+    def test_basic_with_single_signature(self):
+        ilink = InternalLink.FromJsonString('{"highlight_signature":"abc",'
+                                            '"signature":"sig",'
+                                            '"signature_hash":"hash"}')
+        self.assertEqual('abc', ilink.highlight_signature)
+        self.assertEqual('sig', ilink.signature)
+        self.assertEqual('hash', ilink.signature_hash)
+        self.assertSetEqual(set(['abc', 'sig']), set(ilink.GetSignatures()))
+        self.assertEqual('sig', ilink.GetSignature())
 
-  def test_basic_with_single_signature(self):
-    ilink = InternalLink.FromJsonString(
-        '{"highlight_signature":"abc", "signature":"sig","signature_hash":"hash"}'
-    )
-    self.assertEqual('abc', ilink.highlight_signature)
-    self.assertEqual('sig', ilink.signature)
-    self.assertEqual('hash', ilink.signature_hash)
-    self.assertSetEqual(set(['abc', 'sig']), set(ilink.GetSignatures()))
-    self.assertEqual('sig', ilink.GetSignature())
-
-  def test_multi_strings(self):
-    ilink = InternalLink.FromJsonString('''{
+    def test_multi_strings(self):
+        ilink = InternalLink.FromJsonString('''{
         "signature": "foo bar baz",
         "highlight_signature": "hifoo hibar"
       }''')
-    self.assertSetEqual(
-        set(['foo', 'bar', 'baz', 'hifoo', 'hibar']),
-        set(ilink.GetSignatures()))
-    self.assertEqual('foo', ilink.GetSignature())
+        self.assertSetEqual(set(['foo', 'bar', 'baz', 'hifoo', 'hibar']),
+                            set(ilink.GetSignatures()))
+        self.assertEqual('foo', ilink.GetSignature())
 
 
 class TestTextRange(unittest.TestCase):
+    def test_contains(self):
+        r = TextRange(start_line=1, start_column=8, end_line=3, end_column=1)
+        self.assertTrue(r.Contains(1, 8))
+        self.assertTrue(r.Contains(3, 1))
+        self.assertTrue(r.Contains(2, 100))
+        self.assertFalse(r.Contains(1, 7))
+        self.assertFalse(r.Contains(3, 2))
 
-  def test_contains(self):
-    r = TextRange(start_line=1, start_column=8, end_line=3, end_column=1)
-    self.assertTrue(r.Contains(1, 8))
-    self.assertTrue(r.Contains(3, 1))
-    self.assertTrue(r.Contains(2, 100))
-    self.assertFalse(r.Contains(1, 7))
-    self.assertFalse(r.Contains(3, 2))
+    def test_overlaps(self):
+        def _QuadToRange(q):
+            return TextRange(start_line=q[0],
+                             start_column=q[1],
+                             end_line=q[2],
+                             end_column=q[3])
 
-  def test_overlaps(self):
-
-    def _QuadToRange(q):
-      return TextRange(
-          start_line=q[0], start_column=q[1], end_line=q[2], end_column=q[3])
-
-    TestCases = [
-        {
-            "r1": (2, 8, 2, 9),
-            "r2": (1, 1, 1, 100),
-            "result": False
-        },
-        {
-            "r1": (2, 8, 2, 9),
-            "r2": (2, 6, 2, 7),
-            "result": False
-        },
-        {
-            "r1": (2, 8, 2, 9),
-            "r2": (2, 6, 2, 8),
-            "result": True
-        },
-        {
-            "r1": (2, 8, 3, 9),
-            "r2": (2, 6, 2, 8),
-            "result": True
-        },
-        {
-            "r1": (2, 8, 4, 9),
-            "r2": (3, 6, 3, 800),
-            "result": True
-        },
-        {
-            "r1": (2, 8, 4, 9),
-            "r2": (1, 6, 3, 800),
-            "result": True
-        },
-        {
-            "r1": (2, 8, 4, 9),
-            "r2": (3, 6, 300, 800),
-            "result": True
-        },
-        {
-            "r1": (2, 8, 4, 9),
-            "r2": (1, 6, 2, 7),
-            "result": False
-        },
-    ]
-    for t in TestCases:
-      r1 = _QuadToRange(t["r1"])
-      r2 = _QuadToRange(t["r2"])
-      self.assertEqual(t["result"], r1.Overlaps(r2))
-      self.assertEqual(t["result"], r2.Overlaps(r1))
+        TestCases = [
+            {
+                "r1": (2, 8, 2, 9),
+                "r2": (1, 1, 1, 100),
+                "result": False
+            },
+            {
+                "r1": (2, 8, 2, 9),
+                "r2": (2, 6, 2, 7),
+                "result": False
+            },
+            {
+                "r1": (2, 8, 2, 9),
+                "r2": (2, 6, 2, 8),
+                "result": True
+            },
+            {
+                "r1": (2, 8, 3, 9),
+                "r2": (2, 6, 2, 8),
+                "result": True
+            },
+            {
+                "r1": (2, 8, 4, 9),
+                "r2": (3, 6, 3, 800),
+                "result": True
+            },
+            {
+                "r1": (2, 8, 4, 9),
+                "r2": (1, 6, 3, 800),
+                "result": True
+            },
+            {
+                "r1": (2, 8, 4, 9),
+                "r2": (3, 6, 300, 800),
+                "result": True
+            },
+            {
+                "r1": (2, 8, 4, 9),
+                "r2": (1, 6, 2, 7),
+                "result": False
+            },
+        ]
+        for t in TestCases:
+            r1 = _QuadToRange(t["r1"])
+            r2 = _QuadToRange(t["r2"])
+            self.assertEqual(t["result"], r1.Overlaps(r2))
+            self.assertEqual(t["result"], r2.Overlaps(r1))
 
 
 class TestMessage(unittest.TestCase):
+    def test_coerce_known_enum(self):
+        v = Message.Coerce("FOO", Qux)
+        self.assertTrue(isinstance(v, int))
+        self.assertEqual(Qux.FOO, v)
 
-  def test_coerce_known_enum(self):
-    v = Message.Coerce("FOO", Qux)
-    self.assertTrue(isinstance(v, int))
-    self.assertEqual(Qux.FOO, v)
-
-  def test_coerce_uknown_enum(self):
-    with self.assertRaises(ValueError) as e:
-      v = Message.Coerce("incorrect value", Qux)
-    self.assertIn("unrecognized symbolic enum value", str(e.exception))
+    def test_coerce_uknown_enum(self):
+        with self.assertRaises(ValueError) as e:
+            Message.Coerce("incorrect value", Qux)
+        self.assertIn("unrecognized symbolic enum value", str(e.exception))
 
 
 class TestSerialization(unittest.TestCase):
-
-  def test_compoun_message_from_json(self):
-    with open(
-        os.path.join('codesearch', 'testdata', 'compound_response_01.json'),
-        'r') as f:
-      j = f.read()
-    v = CompoundResponse.FromJsonString(j)
-    self.assertIsNone(v.annotation_response)
-    self.assertIsNone(v.dir_info_response)
-    self.assertIsNone(v.file_info_response)
-    self.assertIsNotNone(v.call_graph_response)
-    self.assertIsInstance(v.call_graph_response, list)
-    self.assertEqual(1, len(v.call_graph_response))
-    self.assertIsInstance(v.call_graph_response[0], CallGraphResponse)
-    self.assertEqual(3, len(v.call_graph_response[0].node.children[0].params))
-    self.assertEqual(0, len(v.call_graph_response[0].node.children[1].params))
+    def test_compoun_message_from_json(self):
+        with open(
+                os.path.join('codesearch', 'testdata',
+                             'compound_response_01.json'), 'r') as f:  # noqa
+            j = f.read()
+        v = CompoundResponse.FromJsonString(j)
+        self.assertIsNone(v.annotation_response)
+        self.assertIsNone(v.dir_info_response)
+        self.assertIsNone(v.file_info_response)
+        self.assertIsNotNone(v.call_graph_response)
+        self.assertIsInstance(v.call_graph_response, list)
+        self.assertEqual(1, len(v.call_graph_response))
+        self.assertIsInstance(v.call_graph_response[0], CallGraphResponse)
+        self.assertEqual(3,
+                         len(v.call_graph_response[0].node.children[0].params))
+        self.assertEqual(0,
+                         len(v.call_graph_response[0].node.children[1].params))
 
 
 if __name__ == '__main__':
-  unittest.main()
+    unittest.main()

--- a/codesearch/test_xref_node.py
+++ b/codesearch/test_xref_node.py
@@ -6,99 +6,102 @@
 import unittest
 
 from .client_api import CodeSearch, XrefNode
-from .messages import FileSpec, XrefSingleMatch, KytheXrefKind, KytheNodeKind, \
-    CodeBlockType, CodeBlock
+from .messages import KytheXrefKind, KytheNodeKind, CodeBlockType, CodeBlock
 from .testing_support import InstallTestRequestHandler, DumpCallers
 
 
 class TestXrefNode(unittest.TestCase):
+    def setUp(self):
+        InstallTestRequestHandler()
 
-  def setUp(self):
-    InstallTestRequestHandler()
+    def tearDown(self):
+        DumpCallers()
 
-  def tearDown(self):
-    DumpCallers()
+    def test_simple_xref_lookup(self):
+        cs = CodeSearch(source_root='/chrome/')
+        sigs = [
+            'kythe://chromium?lang=c%2B%2B?path=src/net/http/http_transaction.h'
+            '#CcZF9ULBJvZBNAWPWKhzZ7xbQc1vl21xLHnAyiu2B3Y%3D',
+            'kythe://chromium?lang=c%2B%2B?path=src/net/http/http_transaction.h'
+            '#HttpTransaction%3Anet%23c%23mw7xVzyyv7D',
+            'kythe://chromium?lang=c%2B%2B?path=src/net/http/http_transaction.h'
+            '#pGcqgSa0Alyp5vsTSxVwKkgW86AW0h7GTXQyJ4ry9IM%3D'
+        ]
+        sig = sigs[1]
 
-  def test_simple_xref_lookup(self):
-    cs = CodeSearch(source_root='/chrome/')
-    sigs = [
-        'kythe://chromium?lang=c%2B%2B?path=src/net/http/http_transaction.h#CcZF9ULBJvZBNAWPWKhzZ7xbQc1vl21xLHnAyiu2B3Y%3D',
-        'kythe://chromium?lang=c%2B%2B?path=src/net/http/http_transaction.h#HttpTransaction%3Anet%23c%23mw7xVzyyv7D',
-        'kythe://chromium?lang=c%2B%2B?path=src/net/http/http_transaction.h#pGcqgSa0Alyp5vsTSxVwKkgW86AW0h7GTXQyJ4ry9IM%3D'
-    ]
-    sig = sigs[1]
+        node = XrefNode.FromSignature(cs, sig)
+        members = node.Traverse(KytheXrefKind.EXTENDED_BY)
+        self.assertIsInstance(members, list)
+        self.assertEqual(5, len(members))
+        self.assertIsInstance(members[0], XrefNode)
 
-    node = XrefNode.FromSignature(cs, sig)
-    members = node.Traverse(KytheXrefKind.EXTENDED_BY)
-    self.assertIsInstance(members, list)
-    self.assertEqual(5, len(members))
-    self.assertIsInstance(members[0], XrefNode)
+        display_names = set([m.GetDisplayName() for m in members])
+        self.assertSetEqual(
+            display_names,
+            set([
+                'HttpNetworkTransaction', 'FailingHttpTransaction',
+                'Transaction', 'MockNetworkTransaction',
+                'ThrottlingNetworkTransaction'
+            ]))
 
-    display_names = set([m.GetDisplayName() for m in members])
-    self.assertSetEqual(
-        display_names,
-        set([
-            'HttpNetworkTransaction', 'FailingHttpTransaction', 'Transaction',
-            'MockNetworkTransaction', 'ThrottlingNetworkTransaction'
-        ]))
+    def test_related_annotations(self):
+        cs = CodeSearch(source_root='/chrome/')
+        sig = cs.GetSignatureForSymbol(
+            '/chrome/src/net/http/http_network_transaction.h',
+            'HttpNetworkTransaction')
+        self.assertNotEqual(sig, "", "signature lookup failed")
+        node = XrefNode.FromSignature(cs, sig)
+        related = node.GetRelatedAnnotations()
 
-  def test_related_annotations(self):
-    cs = CodeSearch(source_root='/chrome/')
-    sig = cs.GetSignatureForSymbol(
-        '/chrome/src/net/http/http_network_transaction.h',
-        'HttpNetworkTransaction')
-    self.assertNotEqual(sig, "", "signature lookup failed")
-    node = XrefNode.FromSignature(cs, sig)
-    related = node.GetRelatedAnnotations()
+        found_class = False
+        for annotation in related:
+            if annotation.kythe_xref_kind == KytheNodeKind.RECORD_CLASS:
+                found_class = True
+        self.assertTrue(found_class)
 
-    found_class = False
-    for annotation in related:
-      if annotation.kythe_xref_kind == KytheNodeKind.RECORD_CLASS:
-        found_class = True
-    self.assertTrue(found_class)
+    def test_related_definitions(self):
+        cs = CodeSearch(source_root='/chrome/')
+        sig = cs.GetSignatureForSymbol(
+            '/chrome/src/net/http/http_network_transaction.h',
+            'provided_token_binding_key_')
+        self.assertNotEqual(sig, "", "signature lookup failed")
+        node = XrefNode.FromSignature(cs, sig)
+        related = node.GetRelatedDefinitions()
 
-  def test_related_definitions(self):
-    cs = CodeSearch(source_root='/chrome/')
-    sig = cs.GetSignatureForSymbol(
-        '/chrome/src/net/http/http_network_transaction.h',
-        'provided_token_binding_key_')
-    self.assertNotEqual(sig, "", "signature lookup failed")
-    node = XrefNode.FromSignature(cs, sig)
-    related = node.GetRelatedDefinitions()
+        self.assertEqual(2, len(related))
+        definition = related[1]
+        self.assertEqual(KytheXrefKind.DEFINITION,
+                         definition.single_match.type_id)
+        self.assertEqual('ECPrivateKey', definition.GetDisplayName())
 
-    self.assertEqual(2, len(related))
-    definition = related[1]
-    self.assertEqual(KytheXrefKind.DEFINITION, definition.single_match.type_id)
-    self.assertEqual('ECPrivateKey', definition.GetDisplayName())
+    def test_traverse(self):
+        cs = CodeSearch(source_root='/src/chrome/')
+        cs_file = cs.GetFileInfo('/src/chrome/src/net/http/http_auth.h')
+        sig_block = cs_file.FindCodeBlock(name='ChooseBestChallenge',
+                                          type=CodeBlockType.FUNCTION)
+        self.assertIsNotNone(sig_block)
+        self.assertIsInstance(sig_block, CodeBlock)
+        sig = cs_file.GetSignatureForCodeBlock(sig_block)
+        self.assertIsNotNone(sig)
+        node = XrefNode.FromSignature(cs, sig)
 
-  def test_traverse(self):
-    cs = CodeSearch(source_root='/src/chrome/')
-    cs_file = cs.GetFileInfo('/src/chrome/src/net/http/http_auth.h')
-    sig_block = cs_file.FindCodeBlock(
-        name='ChooseBestChallenge', type=CodeBlockType.FUNCTION)
-    self.assertIsNotNone(sig_block)
-    self.assertIsInstance(sig_block, CodeBlock)
-    sig = cs_file.GetSignatureForCodeBlock(sig_block)
-    self.assertIsNotNone(sig)
-    node = XrefNode.FromSignature(cs, sig)
+        callers = node.Traverse(KytheXrefKind.CALLED_BY)
+        self.assertIsNotNone(callers)
+        self.assertIsInstance(callers, list)
+        self.assertEqual(2, len(callers))
+        self.assertIsInstance(callers[0], XrefNode)
+        self.assertIsInstance(callers[1], XrefNode)
 
-    callers = node.Traverse(KytheXrefKind.CALLED_BY)
-    self.assertIsNotNone(callers)
-    self.assertIsInstance(callers, list)
-    self.assertEqual(2, len(callers))
-    self.assertIsInstance(callers[0], XrefNode)
-    self.assertIsInstance(callers[1], XrefNode)
+        refs = node.Traverse(KytheXrefKind.REFERENCE)
+        self.assertIsNotNone(refs)
+        self.assertIsInstance(refs, list)
+        self.assertEqual(2, len(refs))
+        self.assertIsInstance(refs[0], XrefNode)
 
-    refs = node.Traverse(KytheXrefKind.REFERENCE)
-    self.assertIsNotNone(refs)
-    self.assertIsInstance(refs, list)
-    self.assertEqual(2, len(refs))
-    self.assertIsInstance(refs[0], XrefNode)
-
-    decl = node.Traverse(KytheXrefKind.DECLARATION)
-    self.assertIsInstance(decl, list)
-    self.assertEqual(1, len(decl))
+        decl = node.Traverse(KytheXrefKind.DECLARATION)
+        self.assertIsInstance(decl, list)
+        self.assertEqual(1, len(decl))
 
 
 if __name__ == '__main__':
-  unittest.main()
+    unittest.main()

--- a/codesearch/testing_support.py
+++ b/codesearch/testing_support.py
@@ -16,9 +16,9 @@ from email.message import Message
 
 # Type annotations are only used during static analysis phase.
 try:
-  from typing import Dict, BinaryIO
+    from typing import Dict
 except ImportError:
-  pass
+    pass
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 TEST_DATA_DIR = os.path.join(SCRIPT_DIR, 'testdata')
@@ -27,65 +27,67 @@ RESPONSE_DATA_DIR = os.path.join(TEST_DATA_DIR, 'responses')
 disable_network = False
 
 if sys.version_info < (3, 0):
-  # Python 2
-  from urllib2 import urlopen, Request, HTTPSHandler, install_opener, build_opener, addinfourl, URLError
-  from urlparse import urlparse, parse_qsl, parse_qs, urlunparse
+    # Python 2
+    from urllib2 import urlopen, Request, HTTPSHandler, install_opener, \
+        build_opener, addinfourl, URLError
+    from urlparse import urlparse, parse_qsl, urlunparse
 
-  def GetRequestData(request):
-    return bytes(request.get_data()) if request.has_data() else bytes()
+    def GetRequestData(request):
+        return bytes(request.get_data()) if request.has_data() else bytes()
 
-  def StringFromBytes(b):
-    return str(b)
+    def StringFromBytes(b):
+        return str(b)
 
-  def AddDataToRequest(req, d):
-    req.add_data(d)
+    def AddDataToRequest(req, d):
+        req.add_data(d)
 
-  def GetLocationFromFrame(frame):
-    _, fname, line, fn, _, _ = frame
-    return (fname, line, fn)
+    def GetLocationFromFrame(frame):
+        _, fname, line, fn, _, _ = frame
+        return (fname, line, fn)
 
 else:
-  # Python 3
-  from urllib.request import urlopen, Request, HTTPSHandler, install_opener, build_opener
-  from urllib.response import addinfourl
-  from urllib.error import URLError
-  from urllib.parse import urlparse, parse_qsl, urlunparse
+    # Python 3
+    from urllib.request import urlopen, Request, HTTPSHandler, install_opener, \
+        build_opener
+    from urllib.response import addinfourl
+    from urllib.error import URLError
+    from urllib.parse import urlparse, parse_qsl, urlunparse
 
-  def GetRequestData(request):
-    return request.data if request.data is not None else bytes()
+    def GetRequestData(request):
+        return request.data if request.data is not None else bytes()
 
-  def StringFromBytes(b):
-    return str(b, encoding='utf-8')
+    def StringFromBytes(b):
+        return str(b, encoding='utf-8')
 
-  def AddDataToRequest(req, d):
-    req.data = d
+    def AddDataToRequest(req, d):
+        req.data = d
 
-  def GetLocationFromFrame(frame):
-    return (frame.filename, frame.lineno, frame.function)
+    def GetLocationFromFrame(frame):
+        return (frame.filename, frame.lineno, frame.function)
 
 
 class RequestInfo(object):
 
-  FILE_PREFIXES = ['test_', 'client_api.py']
+    FILE_PREFIXES = ['test_', 'client_api.py']
 
-  def __init__(self, url, data):
-    self.callers = []
-    self.url = url
-    self.data = data
+    def __init__(self, url, data):
+        self.callers = []
+        self.url = url
+        self.data = data
 
-  def AddCallers(self):
-    frames = inspect.stack()
-    for frame in frames:
-      filename, lineno, function = GetLocationFromFrame(frame)
-      basename = os.path.basename(filename)
-      track = False
-      for prefix in RequestInfo.FILE_PREFIXES:
-        if basename.startswith(prefix):
-          track = True
-          break
-      if not track:
-        continue
-      self.callers.append((filename, lineno, function))
+    def AddCallers(self):
+        frames = inspect.stack()
+        for frame in frames:
+            filename, lineno, function = GetLocationFromFrame(frame)
+            basename = os.path.basename(filename)
+            track = False
+            for prefix in RequestInfo.FILE_PREFIXES:
+                if basename.startswith(prefix):
+                    track = True
+                    break
+            if not track:
+                continue
+            self.callers.append((filename, lineno, function))
 
 
 last_request = None
@@ -95,76 +97,75 @@ requests_seen = {}  # type: Dict[str, RequestInfo]
 
 
 def TestDataDir():
-  return TEST_DATA_DIR
+    return TEST_DATA_DIR
 
 
 def DigestFromRequest(req):
-  b = bytearray(req.get_full_url().encode('utf-8'))
-  b.extend(GetRequestData(req))
-  return hashlib.sha1(b).hexdigest()
+    b = bytearray(req.get_full_url().encode('utf-8'))
+    b.extend(GetRequestData(req))
+    return hashlib.sha1(b).hexdigest()
 
 
 class TestHttpHandler(HTTPSHandler):
+    def __init__(self):
+        pass
 
-  def __init__(self):
-    pass
+    def default_open(self, request):
+        return None
 
-  def default_open(self, request):
-    return None
+    def https_open(self, request):
+        global disable_network
+        if disable_network:
+            raise URLError('Network access is disabled')
 
-  def https_open(self, request):
-    global disable_network
-    if disable_network:
-      raise URLError('Network access is disabled')
+        url = request.get_full_url()
+        data = GetRequestData(request)
+        digest = DigestFromRequest(request)
+        filename = digest + ".json"
+        response_file_path = os.path.join(RESPONSE_DATA_DIR, filename)
 
-    url = request.get_full_url()
-    data = GetRequestData(request)
-    digest = DigestFromRequest(request)
-    filename = digest + ".json"
-    response_file_path = os.path.join(RESPONSE_DATA_DIR, filename)
+        global requests_seen
+        if digest not in requests_seen:
+            requests_seen[digest] = RequestInfo(url, data)
 
-    global requests_seen
-    if digest not in requests_seen:
-      requests_seen[digest] = RequestInfo(url, data)
+        requests_seen[digest].AddCallers()
 
-    requests_seen[digest].AddCallers()
+        global last_request
+        last_request = request
 
-    global last_request
-    last_request = request
+        if os.path.exists(response_file_path):
+            f = open(response_file_path, mode='rb')
+            m = Message()
+            m.add_header('Content-Type', 'application/json')
+            resp = addinfourl(f, headers=m, url=url, code=200)
+            resp.msg = 'Success'
+            resp.code = 200
+            return resp
 
-    if os.path.exists(response_file_path):
-      f = open(response_file_path, mode='rb')
-      m = Message()
-      m.add_header('Content-Type', 'application/json')
-      resp = addinfourl(f, headers=m, url=url, code=200)
-      resp.msg = 'Success'
-      resp.code = 200
-      return resp
+        # The file was not there. Create a missing resource file.
+        missing_response_file_path = os.path.join(RESPONSE_DATA_DIR,
+                                                  '{}.missing'.format(digest))
+        with open(missing_response_file_path, mode='wb') as f:
+            s = json.dumps({
+                "url": url,
+                "data": StringFromBytes(data),
+                "filename": filename,
+            })
+            f.write(s.encode('utf-8'))
 
-    # The file was not there. Create a missing resource file.
-    missing_response_file_path = os.path.join(RESPONSE_DATA_DIR,
-                                              '{}.missing'.format(digest))
-    with open(missing_response_file_path, mode='wb') as f:
-      s = json.dumps({
-          "url": url,
-          "data": StringFromBytes(data),
-          "filename": filename,
-      })
-      f.write(s.encode('utf-8'))
+        raise URLError(
+            'URL is not cached. Created missing request record: {}.missing'.
+            format(digest))
 
-    raise URLError(
-        'URL is not cached. Created missing request record: {}.missing'.format(
-            digest))
-
-  def http_open(self, request):
-    return self.https_open(request)
+    def http_open(self, request):
+        return self.https_open(request)
 
 
 def InstallTestRequestHandler(test_data_dir=None):
-  """Any test that makes network requests to https://cs.codesearch.com (i.e.
+    """Any test that makes network requests to https://cs.codesearch.com (i.e.
     those that rely on making network requests) should call this function in
     their respective setUp() functions.
-   
+
     Doing so installs a test request handler that will fail the first time it
     is called with a new URL, but will write out a file indicating which URL
     requests were seen. One can then run the testing_support.py script directly
@@ -179,18 +180,18 @@ def InstallTestRequestHandler(test_data_dir=None):
         testing.
     """
 
-  global TEST_DATA_DIR
-  global RESPONSE_DATA_DIR
+    global TEST_DATA_DIR
+    global RESPONSE_DATA_DIR
 
-  if test_data_dir is not None:
-    TEST_DATA_DIR = test_data_dir
-    RESPONSE_DATA_DIR = os.path.join(TEST_DATA_DIR, 'responses')
+    if test_data_dir is not None:
+        TEST_DATA_DIR = test_data_dir
+        RESPONSE_DATA_DIR = os.path.join(TEST_DATA_DIR, 'responses')
 
-  install_opener(build_opener(TestHttpHandler()))
+    install_opener(build_opener(TestHttpHandler()))
 
 
 def DumpCallers(callers_file=None):
-  """\
+    """\
   DumpCallers writes a trace of callers to a file named `callers.json`. The
   filename can be overridden by the `callers_file` argument.
 
@@ -202,102 +203,107 @@ def DumpCallers(callers_file=None):
   The caller lists can be used to figure out which cached response file was
   accessed by which callers during a test run.
   """
-  global RESPONSE_DATA_DIR
-  global requests_seen
+    global RESPONSE_DATA_DIR
+    global requests_seen
 
-  if callers_file is None:
-    callers_file = os.path.join(RESPONSE_DATA_DIR, 'callers.json')
+    if callers_file is None:
+        callers_file = os.path.join(RESPONSE_DATA_DIR, 'callers.json')
 
-  o = {}
+    o = {}
 
-  try:
-    with open(callers_file, "r") as f:
-      o = json.load(f, encoding='utf-8')
-  except IOError:
-    pass
-  except ValueError:
-    pass
+    try:
+        with open(callers_file, "r") as f:
+            o = json.load(f, encoding='utf-8')
+    except IOError:
+        pass
+    except ValueError:
+        pass
 
-  for digest, ri in requests_seen.items():
-    req = {}
-    callers = []
-    query = ri.data if len(ri.data) > 0 else urlparse(ri.url).query
-    req["query"] = parse_qsl(query)
-    for caller in ri.callers:
-      callers.append({
-          "file": caller[0],
-          "line": caller[1],
-          "function": caller[2]
-      })
-    req["callers"] = callers
+    for digest, ri in requests_seen.items():
+        req = {}
+        callers = []
+        query = ri.data if len(ri.data) > 0 else urlparse(ri.url).query
+        req["query"] = parse_qsl(query)
+        for caller in ri.callers:
+            callers.append({
+                "file": caller[0],
+                "line": caller[1],
+                "function": caller[2]
+            })
+        req["callers"] = callers
 
-    o[digest] = req
+        o[digest] = req
 
-  with open(callers_file, "w") as f:
-    json.dump(o, f, separators=(', ', ': '), indent=2, sort_keys=True)
+    with open(callers_file, "w") as f:
+        json.dump(o, f, separators=(', ', ': '), indent=2, sort_keys=True)
 
 
 def DisableNetwork():
-  global disable_network
-  disable_network = True
+    global disable_network
+    disable_network = True
 
 
 def EnableNetwork():
-  global disable_network
-  disable_network = False
+    global disable_network
+    disable_network = False
 
 
 def LastRequest():
-  return last_request
+    return last_request
 
 
 if __name__ == '__main__':
-  # Attempt to resolve all missing resource requests.
-  HOST_MAPPING = {'cs.chromium.org': 'cs-staging.chromium.org'}
+    # Attempt to resolve all missing resource requests.
+    HOST_MAPPING = {'cs.chromium.org': 'cs-staging.chromium.org'}
 
-  resolved_count = 0
+    resolved_count = 0
 
-  if len(sys.argv) == 2:
-    TEST_DATA_DIR = sys.argv[1]
-    RESPONSE_DATA_DIR = os.path.join(TEST_DATA_DIR, 'responses')
+    if len(sys.argv) == 2:
+        TEST_DATA_DIR = sys.argv[1]
+        RESPONSE_DATA_DIR = os.path.join(TEST_DATA_DIR, 'responses')
 
-  for name in os.listdir(RESPONSE_DATA_DIR):
-    if not name.endswith('.missing'):
-      continue
+    for name in os.listdir(RESPONSE_DATA_DIR):
+        if not name.endswith('.missing'):
+            continue
 
-    print('Resolving {}'.format(name))
+        print('Resolving {}'.format(name))
 
-    with open(os.path.join(RESPONSE_DATA_DIR, name), mode='r') as f:
-      o = json.load(f, encoding='utf-8')
+        with open(os.path.join(RESPONSE_DATA_DIR, name), mode='r') as f:
+            o = json.load(f, encoding='utf-8')
 
-    url, data, filename = o["url"], o["data"], o["filename"]
-    uq = urlparse(url)
-    if uq.netloc in HOST_MAPPING:
-      url = urlunparse([] + [uq[0], HOST_MAPPING[uq.netloc]] + list(uq)[2:6])
+        url, data, filename = o["url"], o["data"], o["filename"]
+        uq = urlparse(url)
+        if uq.netloc in HOST_MAPPING:
+            url = urlunparse([] + [uq[0], HOST_MAPPING[uq.netloc]] +
+                             list(uq)[2:6])
 
-    req = Request(url=url)
-    if data != '':
-      AddDataToRequest(req, data.encode('utf-8'))
+        req = Request(url=url)
+        if data != '':
+            AddDataToRequest(req, data.encode('utf-8'))
 
-    try:
-      response = urlopen(req, timeout=3)
-      result = response.read()
-      data = json.loads(result, encoding='utf-8')
+        try:
+            response = urlopen(req, timeout=3)
+            result = response.read()
+            data = json.loads(result, encoding='utf-8')
 
-      with open(os.path.join(RESPONSE_DATA_DIR, filename), 'w') as f:
-        json.dump(data, f, indent=2, separators=(', ', ': '), encoding='utf-8')
+            with open(os.path.join(RESPONSE_DATA_DIR, filename), 'w') as f:
+                json.dump(data,
+                          f,
+                          indent=2,
+                          separators=(', ', ': '),
+                          encoding='utf-8')
 
-      os.unlink(os.path.join(RESPONSE_DATA_DIR, name))
+            os.unlink(os.path.join(RESPONSE_DATA_DIR, name))
 
-      print('   Resolved. Wrote {}'.format(filename))
-      resolved_count += 1
+            print('   Resolved. Wrote {}'.format(filename))
+            resolved_count += 1
 
-    except Exception as e:
-      print('   FAILED.:{} while looking at {}'.format(str(e), name))
-      raise e
+        except Exception as e:
+            print('   FAILED.:{} while looking at {}'.format(str(e), name))
+            raise e
 
-  if resolved_count > 0:
-    print('\nDon\'t forget to \'git add\' the new files and commit them.')
-  else:
-    print('\nNo URLs resolved\n')
-    sys.exit(1)
+    if resolved_count > 0:
+        print('\nDon\'t forget to \'git add\' the new files and commit them.')
+    else:
+        print('\nNo URLs resolved\n')
+        sys.exit(1)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+show-pep8 = 1
+max-line-length = 80

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,11 @@
 
 from distutils.core import setup
 
-setup(
-    name='codesearch',
-    version='0.1',
-    description='Chromium Codesearch Library',
-    author='Asanka Herath',
-    author_email='asanka@chromium.org',
-    url='https://github.com/chromium/codesearch',
-    packages=['codesearch'],
-    scripts=['ccs'])
+setup(name='codesearch',
+      version='0.1',
+      description='Chromium Codesearch Library',
+      author='Asanka Herath',
+      author_email='asanka@chromium.org',
+      url='https://github.com/chromium/codesearch',
+      packages=['codesearch'],
+      scripts=['ccs'])


### PR DESCRIPTION
Why? Because it works both with yapf and flake8. Therefore is an easier
time for contributors.

@cclauss for https://github.com/chromium/vim-codesearch/pull/18 which prompted this transition.